### PR TITLE
fix: remove --frozen-lockfile flag from pnpm install in release script

### DIFF
--- a/forge-app/Cargo.toml
+++ b/forge-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forge-app"
-version = "0.4.6-rc.4"
+version = "0.4.6-rc.5"
 edition = "2024"
 default-run = "forge-app"
 

--- a/forge-extensions/config/Cargo.toml
+++ b/forge-extensions/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forge-config"
-version = "0.4.6-rc.4"
+version = "0.4.6-rc.5"
 edition = "2024"
 
 [dependencies]

--- a/forge-extensions/omni/Cargo.toml
+++ b/forge-extensions/omni/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forge-omni"
-version = "0.4.6-rc.4"
+version = "0.4.6-rc.5"
 edition = "2024"
 
 [dependencies]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "automagik-forge-frontend",
   "private": true,
-  "version": "0.4.6-rc.4",
+  "version": "0.4.6-rc.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/npx-cli/package.json
+++ b/npx-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "automagik-forge",
   "private": false,
-  "version": "0.4.6-rc.4",
+  "version": "0.4.6-rc.5",
   "main": "index.js",
   "bin": {
     "automagik-forge": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "automagik-forge",
-  "version": "0.4.6-rc.4",
+  "version": "0.4.6-rc.5",
   "private": false,
   "bin": {
     "automagik-forge": "npx-cli/bin/cli.js"


### PR DESCRIPTION
## Summary
Fixes dependency installation failure by removing `--frozen-lockfile` flag from `pnpm install` in the release script.

## Root Cause
After the version bump commit is created and rebased, the lockfile is no longer in the working directory. Running `pnpm install --frozen-lockfile` then fails with:
```
ERR_PNPM_NO_LOCKFILE  Cannot install with "frozen-lockfile" because pnpm-lock.yaml is absent
```

## Fix
Changed `pnpm install --frozen-lockfile` to `pnpm install` to allow pnpm to regenerate the lockfile if needed.

The comment in the code explains:
```js
// Don't use --frozen-lockfile in CI since bump script creates commit before this runs
exec('pnpm install');
```