### PR TITLE
fix: gear button navigates to settings instead of opening project form

### DIFF
--- a/frontend/src/components/layout/navbar.tsx
+++ b/frontend/src/components/layout/navbar.tsx
@@ -23,7 +23,6 @@ import { SearchBar } from '@/components/search-bar';
 import { useSearch } from '@/contexts/search-context';
 import { openTaskForm } from '@/lib/openTaskForm';
 import { useProject } from '@/contexts/project-context';
-import { showProjectForm } from '@/lib/modals';
 import { useOpenProjectInEditor } from '@/hooks/useOpenProjectInEditor';
 import { useDiscordOnlineCount } from '@/hooks/useDiscordOnlineCount';
 import { Breadcrumb } from '@/components/breadcrumb';
@@ -73,12 +72,6 @@ export function Navbar() {
 
   const handleOpenInIDE = () => {
     handleOpenInEditor();
-  };
-
-  const handleProjectSettings = async () => {
-    if (project) {
-      await showProjectForm({ project });
-    }
   };
 
   return (
@@ -138,13 +131,16 @@ export function Navbar() {
                 >
                   <FolderOpen className="h-4 w-4" />
                 </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={handleProjectSettings}
-                  aria-label="Project settings"
-                >
-                  <Settings className="h-4 w-4 -scale-x-100" />
+                <Button variant="ghost" size="icon" asChild aria-label="Settings">
+                  <Link
+                    to={
+                      projectId
+                        ? `/settings/projects?projectId=${projectId}`
+                        : '/settings'
+                    }
+                  >
+                    <Settings className="h-4 w-4" />
+                  </Link>
                 </Button>
                 <Button
                   variant="ghost"


### PR DESCRIPTION
## Problem
The gear button (Settings icon) in the navbar was incorrectly triggering the "Create New Project" dialog instead of navigating to the project settings page.

## Root Cause
The implementation used `onClick={handleProjectSettings}` which called `showProjectForm({ project })` - a modal dialog for creating/editing projects. This was not aligned with the upstream reference implementation.

## Solution
Changed the gear button from an onClick handler to a Link component that navigates to the settings page, matching the upstream reference implementation.

## Changes Made

### File: `frontend/src/components/layout/navbar.tsx`

1. **Replaced onClick handler with Link navigation:**
   - Before: Button with `onClick={handleProjectSettings}`
   - After: Button with `asChild` prop containing a `Link` component
   - Route logic:
     - If `projectId` exists: `/settings/projects?projectId=${projectId}` (project-specific settings)
     - If no `projectId`: `/settings` (general settings)

2. **Removed unused code:**
   - Removed `handleProjectSettings` function
   - Removed `showProjectForm` import from `@/lib/modals`

## Verification

- ✅ TypeScript compilation passes
- ✅ ESLint passes (no new warnings)
- ✅ Implementation matches upstream reference (`upstream/frontend/src/components/layout/navbar.tsx:134-144`)
- ✅ Minimal, targeted changes

## Testing

The gear button now correctly:
- Navigates to `/settings/projects?projectId=<id>` when inside a project
- Navigates to `/settings` when not in a project context
- No longer opens the "Create New Project" modal

Closes #<issue-number-if-applicable>