### PR TITLE
Add --access public flag for first publish of scoped package

### DIFF
--- a/.github/workflows/build-all-platforms.yml
+++ b/.github/workflows/build-all-platforms.yml
@@ -704,7 +704,7 @@ jobs:
         if: steps.check.outputs.published == 'false'
         run: |
           cd npx-cli
-          npm publish --tag ${{ steps.npm-tag.outputs.tag }}
+          npm publish --access public --tag ${{ steps.npm-tag.outputs.tag }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
# Add --access public flag for first publish of scoped package

## Summary
Adds `--access public` flag to the npm publish command in the build-all-platforms workflow. This is required for the first publication of the scoped package `@automagik/forge` under the @automagik organization.

**Context**: The workflow was failing with an OTP (one-time password) error when attempting to publish. This change addresses one part of the solution - npm requires `--access public` for scoped packages to be publicly accessible. The other part requires updating the NPM_TOKEN secret to use an npm Automation token (instead of a granular token) to bypass OTP requirements in CI.

## Review & Testing Checklist for Human
**Risk Level: Yellow** - Single critical line change to publishing workflow with external dependencies

- [ ] **Verify NPM_TOKEN secret is set to an Automation token** (not a granular token) - this is CRITICAL for bypassing OTP in CI
- [ ] **Test the complete publish workflow** by triggering "Build All Platforms" with tag v0.6.2 after merging this PR
- [ ] **Verify successful publication** by checking that @automagik/forge@0.6.2 appears on npmjs.com after the workflow completes

### Test Plan
1. Merge this PR
2. Ensure NPM_TOKEN secret contains an npm Automation token (Classic → Automation type)
3. Trigger workflow: Actions → Build All Platforms → Run workflow → tag: v0.6.2
4. Monitor the publish job to ensure it completes without OTP errors
5. Verify package is available: `npm view @automagik/forge@0.6.2`

### Notes
- This is the first publication of @automagik/forge (previously published as unscoped automagik-forge)
- The `--access public` flag makes the scoped package publicly accessible on npm
- Without an Automation token, the workflow will still fail with OTP errors even with this change
- All platform binaries are already built and cached, so the next workflow run should be fast (~5-10 minutes)

**Link to Devin run**: https://app.devin.ai/sessions/600c769d921b4403881857d4e15fcaa2  
**Requested by**: Felipe Rosa (felipe@namastex.ai) / @namastex888