### PR TITLE
fix: CI builds wrong binary - npm ships upstream server instead of fo…

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -271,7 +271,7 @@ jobs:
 
       - name: Build backend for target
         run: |
-          cargo build --release --target ${{ matrix.target }} -p server
+          cargo build --release --target ${{ matrix.target }} --bin forge-app
           cargo build --release --target ${{ matrix.target }} --bin mcp_task_server
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: ${{ matrix.target == 'aarch64-unknown-linux-gnu' && 'aarch64-linux-gnu-gcc' || '' }}
@@ -295,10 +295,10 @@ jobs:
         run: |
           mkdir -p dist
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-            cp target/${{ matrix.target }}/release/server.exe dist/automagik-forge-${{ matrix.name }}.exe
+            cp target/${{ matrix.target }}/release/forge-app.exe dist/automagik-forge-${{ matrix.name }}.exe
             cp target/${{ matrix.target }}/release/mcp_task_server.exe dist/automagik-forge-mcp-${{ matrix.name }}.exe
           else
-            cp target/${{ matrix.target }}/release/server dist/automagik-forge-${{ matrix.name }}
+            cp target/${{ matrix.target }}/release/forge-app dist/automagik-forge-${{ matrix.name }}
             cp target/${{ matrix.target }}/release/mcp_task_server dist/automagik-forge-mcp-${{ matrix.name }}
           fi
 
@@ -318,7 +318,7 @@ jobs:
         if: runner.os == 'macOS'
         uses: indygreg/apple-code-sign-action@v1
         with:
-          input_path: target/${{ matrix.target }}/release/server
+          input_path: target/${{ matrix.target }}/release/forge-app
           output_path: automagik-forge
           p12_file: certificate.p12
           p12_password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}


### PR DESCRIPTION
…rge-app

Root cause of npm database migration bug (issue #XXX):
- CI workflow was building upstream 'server' binary (-p server)
- Local 'make prod' correctly builds 'forge-app' binary
- This caused npm users to get wrong binary, leading to "index already exists" error

Changes:
- Build: cargo build --bin forge-app (instead of -p server)
- Copy steps: Use forge-app binary (Windows, Linux, macOS)
- macOS signing: Sign forge-app instead of server

This ensures npm package ships same binary as local builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)