### PR TITLE
fix: frontend now properly reads HOST from vite.config.ts

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -66,6 +66,7 @@ export default defineConfig({
     },
   },
   server: {
+    host: process.env.HOST || "127.0.0.1",
     port: parseInt(process.env.FRONTEND_PORT || "3000"),
     proxy: {
       "/api": {

--- a/scripts/dev/run-dev.sh
+++ b/scripts/dev/run-dev.sh
@@ -234,9 +234,8 @@ echo ""
 # Start frontend
 echo "🎨 Starting frontend server..."
 cd frontend
-# Use same HOST binding as backend (from .env)
-VITE_HOST="${HOST:-127.0.0.1}"
-BACKEND_PORT=${BACKEND_PORT} VITE_OPEN=true pnpm run dev -- --port ${FRONTEND_PORT} --host ${VITE_HOST} &
+# HOST is already exported and will be read by vite.config.ts
+BACKEND_PORT=${BACKEND_PORT} VITE_OPEN=true pnpm run dev &
 FRONTEND_PID=$!
 cd ..
 


### PR DESCRIPTION
CLI --host flag wasn't working. Now vite.config.ts reads HOST from environment variable directly, matching how port is configured.

When HOST=0.0.0.0 in .env, Vite will now show network addresses instead of "use --host to expose".

🤖 Generated with [Claude Code](https://claude.com/claude-code)