### PR TITLE
Enable npm OIDC Trusted Publisher for automated releases

### DIFF
--- a/.github/workflows/build-all-platforms.yml
+++ b/.github/workflows/build-all-platforms.yml
@@ -545,6 +545,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      actions: read
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
# Enable npm OIDC Trusted Publisher for automated releases

## Summary

This PR migrates npm publishing from token-based authentication (requiring OTP/2FA) to OIDC Trusted Publisher, enabling fully automated releases without manual intervention.

**Key Changes:**
- Added `environment: release` to the publish job for optional approval gate
- Added OIDC permissions (`id-token: write`, `contents: read`, `actions: read`)
- Removed token-based authentication (`NODE_AUTH_TOKEN` secret usage)
- Removed "Verify npm auth" step that used the token
- Added `--provenance` flag for supply chain security attestation

**Why `actions: read`?** Job-level permissions reset all other scopes to none. The publish job needs `actions: read` to restore caches and download artifacts (flagged by Codex review).

## Review & Testing Checklist for Human

**Critical Prerequisites (must verify before merge):**
- [ ] **Verify npm Trusted Publisher settings match exactly:**
  - Workflow filename: `build-all-platforms.yml` (exact match)
  - Environment name: `release` (exact match)
  - Organization: `namastexlabs`
  - Repository: `automagik-forge`
  - If these don't match, OIDC will fail with authentication errors
- [ ] **Create GitHub environment named `release`** at https://github.com/namastexlabs/automagik-forge/settings/environments
  - Optional: Add required reviewers for approval gate
  - Optional: Add deployment branch rule for `v*` tags
- [ ] **Test with a throwaway tag first** (e.g., `v0.6.4-rc.0`) before using on a real release
  - Verify OIDC authentication works
  - Verify caches and artifacts are restored successfully
  - Verify provenance attestation is generated
  - Check that environment approval gate triggers (if configured)

**Additional Considerations:**
- [ ] Consider disabling or updating `.github/workflows/publish.yml` to prevent duplicate publish attempts or reintroduction of token auth
- [ ] Verify npm CLI version supports OIDC (npm ≥9, Node 20 runners have npm 10)

### Notes

**What happens on next release:**
1. Tag push triggers `build-all-platforms.yml`
2. Publish job requests approval via `release` environment (if reviewers configured)
3. npm publish uses OIDC authentication (no OTP prompt)
4. Package published with provenance attestation

**Rollback plan:** If OIDC fails, you can temporarily revert this PR and use the old token-based flow with OTP.

**Session:** https://app.devin.ai/sessions/c274e8e6115947cca3b11a88e3540d43  
**Requested by:** Felipe Rosa (felipe@namastex.ai) / @namastex888