### PR TITLE
fix: Android backend startup error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,6 +216,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_log-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
+
+[[package]]
+name = "android_logger"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b07e8e73d720a1f2e4b6014766e6039fd2e96a4fa44e2a78d0e1fa2ff49826"
+dependencies = [
+ "android_log-sys",
+ "env_filter",
+ "log",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1400,6 +1417,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "env_home"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1623,6 +1650,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 name = "forge-app"
 version = "0.6.3"
 dependencies = [
+ "android_logger",
  "anyhow",
  "axum",
  "base64 0.22.1",
@@ -1638,6 +1666,7 @@ dependencies = [
  "jni",
  "json-patch",
  "local-deployment",
+ "log",
  "mime_guess",
  "notify 6.1.1",
  "regex",

--- a/android/app/src/main/java/ai/namastex/forge/MainActivity.kt
+++ b/android/app/src/main/java/ai/namastex/forge/MainActivity.kt
@@ -5,6 +5,8 @@ import android.os.Bundle
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.webkit.WebSettings
+import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import kotlinx.coroutines.*
 
@@ -40,10 +42,24 @@ class MainActivity : AppCompatActivity() {
 
         // Start Rust server in background
         serverJob = CoroutineScope(Dispatchers.IO).launch {
-            val port = startServer()
-            withContext(Dispatchers.Main) {
-                // Load app once server is ready
-                webView.loadUrl("http://127.0.0.1:$port")
+            try {
+                val port = startServer()
+                
+                if (port <= 0) {
+                    withContext(Dispatchers.Main) {
+                        showServerStartupError()
+                    }
+                    return@launch
+                }
+                
+                withContext(Dispatchers.Main) {
+                    // Load app once server is ready
+                    webView.loadUrl("http://127.0.0.1:$port")
+                }
+            } catch (e: Exception) {
+                withContext(Dispatchers.Main) {
+                    showServerStartupError(e.message)
+                }
             }
         }
     }
@@ -60,5 +76,24 @@ class MainActivity : AppCompatActivity() {
         } else {
             super.onBackPressed()
         }
+    }
+
+    private fun showServerStartupError(details: String? = null) {
+        val message = buildString {
+            append("Failed to start the Forge backend server.\n\n")
+            if (details != null) {
+                append("Error: $details\n\n")
+            }
+            append("Please check the logs (adb logcat) for more details.")
+        }
+
+        AlertDialog.Builder(this)
+            .setTitle("Server Startup Failed")
+            .setMessage(message)
+            .setPositiveButton("Exit") { _, _ ->
+                finish()
+            }
+            .setCancelable(false)
+            .show()
     }
 }

--- a/forge-app/Cargo.toml
+++ b/forge-app/Cargo.toml
@@ -63,9 +63,11 @@ forge-config = { path = "../forge-extensions/config" }
 
 # Android JNI
 jni = { version = "0.21", optional = true }
+android_logger = { version = "0.14", optional = true }
+log = "0.4"
 
 [features]
-android = ["jni"]
+android = ["jni", "android_logger"]
 
 [dev-dependencies]
 httpmock = "0.7"


### PR DESCRIPTION
# fix: Android backend startup error handling

## Summary
Fixes the Android app bug where users see "ERR_CONNECTION_REFUSED" when the backend server fails to start. The root cause was that the JNI `startServer()` function was returning the port number even when the server failed to signal readiness, causing the WebView to attempt connecting to a non-existent server.

**Changes:**
- **forge-app/src/android.rs**: Modified JNI function to return `-1` on server startup failure instead of returning the port number. Added proper error logging and resource cleanup.
- **forge-app/Cargo.toml**: Added `android_logger` dependency to forward Rust logs to Android Logcat for better debugging.
- **MainActivity.kt**: Added error handling to check for negative return values and display a user-friendly error dialog instead of attempting to load the WebView.

## Review & Testing Checklist for Human

**Risk Level: 🟡 Yellow** - Changes look correct but cannot be tested without building and running the Android APK.

- [ ] **Build and test the Android APK** - Verify the app builds successfully with the new dependencies and runs on a device/emulator
- [ ] **Test server startup failure scenario** - Simulate a server startup failure (e.g., by introducing a deliberate error in server initialization) and verify:
  - The error dialog appears with a clear message
  - The app doesn't attempt to load the WebView
  - Logs appear in `adb logcat` with the "ForgeApp" tag
- [ ] **Test normal startup flow** - Verify the app still works correctly when the server starts successfully
- [ ] **Review error message UX** - The error dialog mentions "adb logcat" which is technical. Consider if this is appropriate for end users or if we need a more user-friendly message

### Test Plan
1. Build the Android APK: `./scripts/build-android.sh --release`
2. Install on device/emulator
3. Launch the app and verify it loads successfully
4. Check `adb logcat | grep ForgeApp` to see server startup logs
5. To test error handling, temporarily modify `run_server_with_readiness` to return an error and rebuild

### Notes
- The `android_logger` dependency version is 0.14.1 (latest compatible), though 0.15.1 exists. Chose 0.14 for stability.
- The fix improves error reporting but doesn't address the root cause of why the server might fail to start. If server startup failures are common, we should investigate those separately.
- The error dialog is non-dismissible (`.setCancelable(false)`) and only offers an "Exit" button, which seems appropriate for a fatal error.

---
**Link to Devin run:** https://app.devin.ai/sessions/2ec9084493c444aaa6a7a11852e545e0  
**Requested by:** Felipe Rosa (felipe@namastex.ai) / @namastex888