### PR TITLE
feat: Apply mobile theme design system to desktop UI

### DIFF
--- a/frontend/src/components/DevBanner.tsx
+++ b/frontend/src/components/DevBanner.tsx
@@ -7,7 +7,7 @@ export function DevBanner() {
   }
 
   return (
-    <div className="bg-orange-500 text-white text-center py-2 px-4 text-sm font-medium border-b border-orange-600">
+    <div className="bg-warning/20 text-warning text-center py-2 px-4 text-sm font-medium border-b border-warning/40">
       <div className="flex items-center justify-center gap-2">
         <AlertTriangle className="h-4 w-4" />
         <span>Development Mode - This is a development build</span>

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -72,39 +72,53 @@
   }
 
   /* Dark defaults (used if no theme class but user prefers dark) */
+  /* Updated to match mobile theme design system */
   .dark {
     color-scheme: dark;
-    --_background: 48 4% 16%;
-    --_foreground: 48 7% 85%;
-    --_primary: var(--_muted);
-    --_primary-foreground: var(--_muted-foreground);
-    --_secondary: var(--_muted);
-    --_secondary-foreground: 48 2% 65%;
-    --_muted: 60 2% 18%;
-    --_muted-foreground: var(--_foreground);
-    --_accent: var(--_background);
-    --_accent-foreground: 210 40% 98%;
-    --_destructive: 0 45% 55%;
-    --_destructive-foreground: var(--_background-foreground);
-    --_border: 60 2% 25%;
-    --_input: var(--_border);
-    --_ring: 212.7 26.8% 83.9%;
+    /* Background: #1A1625 = hsl(277, 28%, 13%) */
+    --_background: 277 28% 13%;
+    /* Foreground: #FFFFFF = hsl(0, 0%, 100%) */
+    --_foreground: 0 0% 100%;
+    /* Primary/Muted: #2A2435 = hsl(277, 20%, 18%) */
+    --_primary: 277 20% 18%;
+    --_primary-foreground: 0 0% 100%;
+    --_secondary: 277 20% 18%;
+    /* Secondary foreground: #A8A8B8 = hsl(240, 11%, 69%) */
+    --_secondary-foreground: 240 11% 69%;
+    /* Muted: #2A2435 = hsl(277, 20%, 18%) */
+    --_muted: 277 20% 18%;
+    --_muted-foreground: 0 0% 100%;
+    /* Accent: #252030 = hsl(277, 23%, 16%) */
+    --_accent: 277 23% 16%;
+    --_accent-foreground: 0 0% 100%;
+    /* Destructive: #FF4D6A = hsl(349, 100%, 65%) */
+    --_destructive: 349 100% 65%;
+    --_destructive-foreground: 0 0% 100%;
+    /* Border: #3E3850 = hsl(264, 17%, 28%) */
+    --_border: 264 17% 28%;
+    --_input: 264 17% 28%;
+    /* Ring: #E91EFF = hsl(293, 100%, 56%) */
+    --_ring: 293 100% 56%;
 
-    /* Status (dark) */
-    --_success: 138.5 76.5% 47.7%;
-    --_success-foreground: 138.5 76.5% 96.7%;
-    --_warning: 32.2 95% 44.1%;
-    --_warning-foreground: 26 83.3% 14.1%;
-    --_info: 217.2 91.2% 59.8%;
-    --_info-foreground: 222.2 84% 4.9%;
-    --_neutral: 217.2 32.6% 17.5%;
-    --_neutral-foreground: 210 40% 98%;
+    /* Status (dark) - matching mobile design system */
+    /* Success: #00FF88 = hsl(153, 100%, 50%) */
+    --_success: 153 100% 50%;
+    --_success-foreground: 0 0% 100%;
+    /* Warning: #FFD700 = hsl(51, 100%, 50%) */
+    --_warning: 51 100% 50%;
+    --_warning-foreground: 277 28% 13%;
+    /* Info: #4A9EFF = hsl(214, 100%, 65%) */
+    --_info: 214 100% 65%;
+    --_info-foreground: 0 0% 100%;
+    /* Neutral: #342E42 = hsl(264, 19%, 22%) */
+    --_neutral: 264 19% 22%;
+    --_neutral-foreground: 0 0% 100%;
 
     /* Console (dark) */
-    --_console-background: 0 0% 0%;
-    --_console-foreground: 210 40% 98%;
-    --_console-success: 138.5 76.5% 47.7%;
-    --_console-error: 0 84.2% 60.2%;
+    --_console-background: 277 28% 13%;
+    --_console-foreground: 0 0% 100%;
+    --_console-success: 153 100% 50%;
+    --_console-error: 349 100% 65%;
   }
 }
 


### PR DESCRIPTION
# feat: Apply mobile theme design system to desktop UI

## Summary

Updates desktop UI to match the mobile theme design system for visual consistency across the entire app. This PR applies the mobile dark theme color palette (defined in `.genie/wishes/mobile-native-app/specs/design-system-and-branding-spec.md`) to the desktop UI by updating CSS variables.

**Key Changes:**
- Updated `.dark` theme CSS variables in `frontend/src/styles/index.css` to use mobile theme colors:
  - Background: `#1A1625` (dark purple-tinted)
  - Surface: `#2A2435` (card/surface color)
  - Border: `#3E3850` (border color)
  - Brand: `#E91EFF` (magenta), `#00D9FF` (cyan)
  - Text: `#FFFFFF` (primary), `#A8A8B8` (secondary)
  - Status: `#00FF88` (success), `#FFD700` (warning), `#FF4D6A` (error)
- Updated `DevBanner.tsx` to use theme-aware warning colors (`bg-warning/20`) instead of hardcoded orange

**Impact:**
Desktop components already use CSS variable classes (`bg-background`, `bg-muted`, `border-b`, etc.), so they automatically inherit the new mobile theme colors without requiring individual component updates.

## Review & Testing Checklist for Human

**⚠️ Risk Level: YELLOW** - Visual changes that need verification

- [ ] **Visual verification**: Open the desktop app and verify the UI matches the mobile theme aesthetic (dark purple backgrounds, magenta/cyan accents)
- [ ] **DevBanner appearance**: Check that the development banner looks appropriate with the new yellow/gold warning color (changed from orange)
- [ ] **Component consistency**: Spot-check various desktop components (Navbar, TasksLayout, panels, modals) to ensure colors look correct and there are no contrast issues
- [ ] **VSCode extension context**: If applicable, test in VSCode extension mode to ensure VSCode theme variables don't unexpectedly override the new colors

### Test Plan
1. Run `make dev` and open the desktop app in browser
2. Navigate through different pages (Projects, Tasks, Settings)
3. Compare desktop UI colors with mobile UI (resize browser to < 768px to see mobile layout)
4. Verify the overall aesthetic matches and the app "speaks the same visual language"

### Notes
- Only dark theme was updated (mobile design system specifies dark as primary theme)
- Light theme variables were not modified in this PR
- TypeScript check: ✅ Passes
- Lint check: ✅ No new warnings introduced
- Related to mobile theme implementation: commits 3e32c59e, f16483af, 0885d75f

**Session Info:**
- Devin session: https://app.devin.ai/sessions/47ba4e5e0a3f4a0c95bf3721cec00160
- Requested by: Felipe Rosa (felipe@namastex.ai) / @namastex888