### PR TITLE
fiz: Add padding to kanban cards and textarea

### DIFF
--- a/frontend/src/components/ui/auto-expanding-textarea.tsx
+++ b/frontend/src/components/ui/auto-expanding-textarea.tsx
@@ -55,7 +55,7 @@ const AutoExpandingTextarea = React.forwardRef<
   return (
     <textarea
       className={cn(
-        'bg-background p-0 min-h-[120px] w-full text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50 resize-none overflow-y-auto overflow-x-hidden whitespace-pre-wrap break-words',
+        'bg-background p-3 min-h-[120px] w-full text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50 resize-none overflow-y-auto overflow-x-hidden whitespace-pre-wrap break-words',
         className
       )}
       ref={textareaRef}

--- a/frontend/src/components/ui/shadcn-io/kanban/index.tsx
+++ b/frontend/src/components/ui/shadcn-io/kanban/index.tsx
@@ -163,7 +163,7 @@ export const KanbanHeader = (props: KanbanHeaderProps) => {
   return (
     <Card
       className={cn(
-        'sticky top-0 z-20 flex shrink-0 items-center gap-2 p-3 border-b border-dashed flex gap-2',
+        'sticky top-0 z-20 flex shrink-0 items-center gap-2 p-3 border-b border-dashed flex gap-2 mx-2 mb-2',
         'bg-background',
         props.className
       )}


### PR DESCRIPTION
## Summary
Add consistent padding/spacing to kanban components:
- Add horizontal padding (px-2) and vertical gap (gap-2) to KanbanCards container
- Add horizontal margin (mx-2) and bottom margin (mb-2) to KanbanHeader
- Add padding (p-3) to AutoExpandingTextarea for text breathing room

## Changes
- `frontend/src/components/ui/shadcn-io/kanban/index.tsx`: Add spacing to cards container and header
- `frontend/src/components/ui/auto-expanding-textarea.tsx`: Add padding to textarea

## Visual Impact
Cards now have proper spacing from column edges instead of being glued to them. Header and first card have consistent spacing throughout.