### PR TITLE
Fix build error: remove stale mcp_task_server binary references

### DIFF
--- a/.github/workflows/build-all-platforms.yml
+++ b/.github/workflows/build-all-platforms.yml
@@ -205,7 +205,6 @@ jobs:
           POSTHOG_API_ENDPOINT: ${{ secrets.POSTHOG_API_ENDPOINT }}
         run: |
           cargo build --release --target ${{ matrix.target }}
-          cargo build --release --target ${{ matrix.target }} --bin mcp_task_server
         shell: bash
 
       - name: Build Rust binaries (Linux zigbuild)
@@ -224,7 +223,6 @@ jobs:
         run: |
           # Use cargo-zigbuild (via zig toolchain) for Linux cross targets
           cargo zigbuild --release --target ${{ matrix.target }}
-          cargo zigbuild --release --target ${{ matrix.target }} --bin mcp_task_server
         shell: bash
 
       - name: Build Rust binaries (non-Windows, native)
@@ -243,7 +241,6 @@ jobs:
           POSTHOG_API_ENDPOINT: ${{ secrets.POSTHOG_API_ENDPOINT }}
         run: |
           cargo build --release --target ${{ matrix.target }}
-          cargo build --release --target ${{ matrix.target }} --bin mcp_task_server
         shell: bash
       
       - name: Package binaries (Windows)
@@ -257,7 +254,7 @@ jobs:
           Move-Item "automagik-forge.zip" "npx-cli/dist/${{ matrix.platform }}/"
           Remove-Item "automagik-forge.exe"
 
-          Copy-Item "target/${{ matrix.target }}/release/mcp_task_server.exe" "automagik-forge-mcp.exe"
+          Copy-Item "target/${{ matrix.target }}/release/forge-app.exe" "automagik-forge-mcp.exe"
           Compress-Archive -Path "automagik-forge-mcp.exe" -DestinationPath "automagik-forge-mcp.zip" -Force
           Move-Item "automagik-forge-mcp.zip" "npx-cli/dist/${{ matrix.platform }}/"
           Remove-Item "automagik-forge-mcp.exe"
@@ -273,7 +270,7 @@ jobs:
           mv automagik-forge.zip npx-cli/dist/${{ matrix.platform }}/
           rm automagik-forge
 
-          cp target/${{ matrix.target }}/release/mcp_task_server automagik-forge-mcp
+          cp target/${{ matrix.target }}/release/forge-app automagik-forge-mcp
           zip -q automagik-forge-mcp.zip automagik-forge-mcp
           mv automagik-forge-mcp.zip npx-cli/dist/${{ matrix.platform }}/
           rm automagik-forge-mcp
@@ -454,7 +451,6 @@ jobs:
           CARGO_TARGET_AARCH64_LINUX_ANDROID_AR: ${{ env.ANDROID_NDK_HOME }}/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar
         run: |
           cargo build --release --target aarch64-linux-android
-          cargo build --release --target aarch64-linux-android --bin mcp_task_server
 
       - name: Build Rust library for Android (JNI for APK)
         if: env.SKIP_APK != 'true'
@@ -494,7 +490,7 @@ jobs:
           mv automagik-forge.zip npx-cli/dist/android-arm64/
           rm automagik-forge
 
-          cp target/aarch64-linux-android/release/mcp_task_server automagik-forge-mcp
+          cp target/aarch64-linux-android/release/forge-app automagik-forge-mcp
           zip -q automagik-forge-mcp.zip automagik-forge-mcp
           mv automagik-forge-mcp.zip npx-cli/dist/android-arm64/
           rm automagik-forge-mcp

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -269,7 +269,6 @@ jobs:
       - name: Build backend for target
         run: |
           cargo build --release --target ${{ matrix.target }} --bin forge-app
-          cargo build --release --target ${{ matrix.target }} --bin mcp_task_server
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: ${{ matrix.target == 'aarch64-unknown-linux-gnu' && 'aarch64-linux-gnu-gcc' || '' }}
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
@@ -293,10 +292,10 @@ jobs:
           mkdir -p dist
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
             cp target/${{ matrix.target }}/release/forge-app.exe dist/automagik-forge-${{ matrix.name }}.exe
-            cp target/${{ matrix.target }}/release/mcp_task_server.exe dist/automagik-forge-mcp-${{ matrix.name }}.exe
+            cp target/${{ matrix.target }}/release/forge-app.exe dist/automagik-forge-mcp-${{ matrix.name }}.exe
           else
             cp target/${{ matrix.target }}/release/forge-app dist/automagik-forge-${{ matrix.name }}
-            cp target/${{ matrix.target }}/release/mcp_task_server dist/automagik-forge-mcp-${{ matrix.name }}
+            cp target/${{ matrix.target }}/release/forge-app dist/automagik-forge-mcp-${{ matrix.name }}
           fi
 
       # Code signing for macOS only
@@ -340,7 +339,7 @@ jobs:
         if: runner.os == 'macOS'
         uses: indygreg/apple-code-sign-action@v1
         with:
-          input_path: target/${{ matrix.target }}/release/mcp_task_server
+          input_path: target/${{ matrix.target }}/release/forge-app
           output_path: automagik-forge-mcp
           p12_file: certificate.p12
           p12_password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}

--- a/forge-app/src/lib.rs
+++ b/forge-app/src/lib.rs
@@ -34,7 +34,8 @@ fn find_process_using_port(port: u16, _host: &str) -> Option<String> {
 
     // Try using ss command first (more modern)
     if let Ok(output) = Command::new("ss").args(["-tulpn"]).output()
-        && let Ok(stdout) = String::from_utf8(output.stdout) {
+        && let Ok(stdout) = String::from_utf8(output.stdout)
+    {
         for line in stdout.lines() {
             if line.contains(&format!(":{}", port)) {
                 // Extract PID from ss output (format: users:(("process",pid=12345,fd=3)))
@@ -53,7 +54,8 @@ fn find_process_using_port(port: u16, _host: &str) -> Option<String> {
     if let Ok(output) = Command::new("lsof")
         .args(["-i", &format!(":{}", port), "-t"])
         .output()
-        && let Ok(pid_str) = String::from_utf8(output.stdout) {
+        && let Ok(pid_str) = String::from_utf8(output.stdout)
+    {
         let pid = pid_str.trim();
         if !pid.is_empty() {
             return Some(format!("Process with PID {} is using this port", pid));

--- a/forge-app/src/main.rs
+++ b/forge-app/src/main.rs
@@ -39,13 +39,16 @@ fn parse_port_flag() -> Option<u16> {
         if let Some(port_str) = arg
             .strip_prefix("--port=")
             .or_else(|| arg.strip_prefix("-p="))
-            && let Ok(port) = port_str.parse::<u16>() {
+            && let Ok(port) = port_str.parse::<u16>()
+        {
             return Some(port);
         }
 
         // Handle --port 8888 or -p 8888
-        if (arg == "--port" || arg == "-p") && i + 1 < args.len()
-            && let Ok(port) = args[i + 1].parse::<u16>() {
+        if (arg == "--port" || arg == "-p")
+            && i + 1 < args.len()
+            && let Ok(port) = args[i + 1].parse::<u16>()
+        {
             return Some(port);
         }
     }

--- a/forge-app/src/router.rs
+++ b/forge-app/src/router.rs
@@ -1572,7 +1572,8 @@ async fn get_master_genie_neurons(
     for task in neuron_tasks {
         // Get latest attempt for this neuron task (fetch_all returns newest first)
         if let Ok(attempts) = TaskAttempt::fetch_all(pool, Some(task.id)).await
-            && let Some(attempt) = attempts.into_iter().next() {
+            && let Some(attempt) = attempts.into_iter().next()
+        {
             // Parse executor to get variant (e.g., "CLAUDE_CODE:WISH" → "WISH")
             let neuron_type = if let Some((_base, variant)) = attempt.executor.split_once(':') {
                 variant.to_string() // Keep uppercase to match profile variants

--- a/forge-app/src/services/genie_profiles.rs
+++ b/forge-app/src/services/genie_profiles.rs
@@ -395,7 +395,11 @@ impl GenieProfileLoader {
         // 1. Scan global agents (.genie/agents/)
         let global_agents_dir = genie_root.join("agents");
         if global_agents_dir.exists() {
-            files.extend(Self::scan_directory(&global_agents_dir, None, AgentType::Agent)?);
+            files.extend(Self::scan_directory(
+                &global_agents_dir,
+                None,
+                AgentType::Agent,
+            )?);
         }
 
         // 2. Scan collective agents
@@ -460,7 +464,11 @@ impl GenieProfileLoader {
                 }
 
                 // Recursively scan subdirectories
-                files.extend(Self::scan_directory(&path, collective.clone(), agent_type.clone())?);
+                files.extend(Self::scan_directory(
+                    &path,
+                    collective.clone(),
+                    agent_type.clone(),
+                )?);
                 continue;
             }
 
@@ -582,8 +590,8 @@ impl GenieProfileLoader {
         let front_matter_yaml = &captures[1];
         let body = captures[2].trim().to_string();
 
-        let metadata: AgentFrontmatter = serde_yaml::from_str(front_matter_yaml)
-            .context("Failed to parse frontmatter YAML")?;
+        let metadata: AgentFrontmatter =
+            serde_yaml::from_str(front_matter_yaml).context("Failed to parse frontmatter YAML")?;
 
         Ok((metadata, body))
     }

--- a/local-build.sh
+++ b/local-build.sh
@@ -62,7 +62,6 @@ rm -rf target/release/.fingerprint/forge-app-*/
 
 echo "🔨 Building Rust binaries with fresh frontend embed..."
 cargo build --release --bin forge-app
-cargo build --release --bin mcp_task_server
 
 echo "📦 Creating distribution package..."
 
@@ -93,8 +92,8 @@ zip_one "automagik-forge${BIN_EXT}" "automagik-forge.zip"
 rm -f "automagik-forge${BIN_EXT}"
 mv "automagik-forge.zip" "npx-cli/dist/$PLATFORM_DIR/automagik-forge.zip"
 
-# Copy and zip the MCP binary
-cp "target/release/mcp_task_server${BIN_EXT}" "automagik-forge-mcp${BIN_EXT}"
+# Copy and zip the MCP binary (currently a copy of forge-app)
+cp "target/release/forge-app${BIN_EXT}" "automagik-forge-mcp${BIN_EXT}"
 zip_one "automagik-forge-mcp${BIN_EXT}" "automagik-forge-mcp.zip"
 rm -f "automagik-forge-mcp${BIN_EXT}"
 mv "automagik-forge-mcp.zip" "npx-cli/dist/$PLATFORM_DIR/automagik-forge-mcp.zip"

--- a/scripts/build/build.sh
+++ b/scripts/build/build.sh
@@ -167,10 +167,9 @@ if [ "$NEEDS_BACKEND_BUILD" = "true" ]; then
   export SQLX_OFFLINE=true
 
   cargo build --release --bin forge-app
-  cargo build --release --bin mcp_task_server
 else
   # Verify binaries actually exist before skipping
-  if [ ! -f "target/release/forge-app${BIN_EXT}" ] || [ ! -f "target/release/mcp_task_server${BIN_EXT}" ]; then
+  if [ ! -f "target/release/forge-app${BIN_EXT}" ]; then
     echo "⚠️  Backend binaries missing despite no detected changes - rebuilding"
 
     # Use SQLx offline mode for compilation
@@ -178,7 +177,6 @@ else
     export SQLX_OFFLINE=true
 
     cargo build --release --bin forge-app
-    cargo build --release --bin mcp_task_server
   else
     echo "⏭️  Skipping backend build (no changes)"
     echo "   Using existing binaries from target/release/"
@@ -210,8 +208,8 @@ zip_one "automagik-forge${BIN_EXT}" "automagik-forge.zip"
 rm -f "automagik-forge${BIN_EXT}"
 mv "automagik-forge.zip" "npx-cli/dist/$PLATFORM_DIR/automagik-forge.zip"
 
-# Copy and zip the MCP binary
-cp "target/release/mcp_task_server${BIN_EXT}" "automagik-forge-mcp${BIN_EXT}"
+# Copy and zip the MCP binary (currently a copy of forge-app)
+cp "target/release/forge-app${BIN_EXT}" "automagik-forge-mcp${BIN_EXT}"
 zip_one "automagik-forge-mcp${BIN_EXT}" "automagik-forge-mcp.zip"
 rm -f "automagik-forge-mcp${BIN_EXT}"
 mv "automagik-forge-mcp.zip" "npx-cli/dist/$PLATFORM_DIR/automagik-forge-mcp.zip"

--- a/scripts/rebrand.sh
+++ b/scripts/rebrand.sh
@@ -499,7 +499,7 @@ After restoration, verify:
 - [ ] `cargo check --workspace` passes
 - [ ] `advanced_tools.rs` compiles (if restored)
 - [ ] `pub mod advanced_tools;` in `crates/server/src/mcp/mod.rs`
-- [ ] MCP server starts: `cargo run --bin mcp_task_server -- --advanced`
+- [ ] MCP server starts: `cargo run -p forge-app -- --mcp`
 - [ ] Default MCP config has `forge` and `genie` servers
 - [ ] Backend port 8887 configured in MCP config
 - [ ] Genie notification sounds present


### PR DESCRIPTION
# Fix build error: remove stale mcp_task_server binary references

## Summary

This PR fixes a build error where the build scripts and CI workflows were trying to compile a `mcp_task_server` binary that no longer exists in the codebase. The error occurred when running `make prod`:

```
error: no bin target named `mcp_task_server` in default-run packages
help: available bin targets:
    forge-app
    generate-forge-types
```

**Changes made:**
- Removed all `cargo build --bin mcp_task_server` commands from build scripts and CI workflows
- Updated packaging steps to copy `forge-app` binary as `automagik-forge-mcp` instead of building a separate binary
- Updated documentation in `scripts/rebrand.sh` to reflect the correct command
- Applied `cargo fmt` formatting fixes to several Rust files

**Important note:** The `automagik-forge-mcp` distribution artifact is now just a copy of the `forge-app` binary. MCP mode functionality is not currently implemented in `forge-app` (no `--mcp` flag handling exists in the code). This PR only fixes the build error; MCP functionality is a separate concern.

## Review & Testing Checklist for Human

- [ ] **Verify both binaries are created**: Run `make prod` locally and confirm both `automagik-forge.zip` and `automagik-forge-mcp.zip` are created in `npx-cli/dist/`
- [ ] **Check CI passes on all platforms**: Ensure the CI workflows successfully build for Linux (x64/ARM64), Windows, macOS, and Android
- [ ] **Confirm MCP expectations**: Understand that `automagik-forge-mcp` is currently just a copy of `forge-app` with no special MCP behavior (the npx-cli wrapper passes `--mcp` flag, but forge-app doesn't handle it)
- [ ] **Test the build completes**: Verify `make prod` runs without the "no bin target named mcp_task_server" error

### Test Plan
1. Run `make prod` locally and verify it completes successfully
2. Check that both zip files exist: `ls npx-cli/dist/linux-x64/*.zip`
3. Wait for CI to pass on all platforms before merging

### Notes
- The Rust formatting changes (in `forge-app/src/*.rs`) are unrelated to the main fix but improve code quality
- This PR does not implement MCP functionality; it only removes stale references to a deleted binary
- The build was tested locally and completed successfully with the server starting on port 8887

---
**Link to Devin run:** https://app.devin.ai/sessions/9ef1b5efa9c442a0956e90ab131c8758  
**Requested by:** Felipe Rosa (felipe@namastex.ai) / @namastex888