### PR TITLE
fix: re-validate GitHub token after authentication to prevent duplicate login prompts

### DIFF
--- a/frontend/src/components/config-provider.tsx
+++ b/frontend/src/components/config-provider.tsx
@@ -110,7 +110,7 @@ export function UserSystemProvider({ children }: UserSystemProviderProps) {
     }
   }, [config?.language]);
 
-  // Check GitHub token validity after config loads
+  // Check GitHub token validity after config loads and when GitHub config changes
   useEffect(() => {
     if (loading) return;
     const checkToken = async () => {
@@ -129,7 +129,7 @@ export function UserSystemProvider({ children }: UserSystemProviderProps) {
       }
     };
     checkToken();
-  }, [loading]);
+  }, [loading, config?.github]);
 
   const updateConfig = useCallback((updates: Partial<Config>) => {
     setConfig((prev) => (prev ? { ...prev, ...updates } : null));


### PR DESCRIPTION
## Summary
Fixes GitHub authentication asking users to re-authenticate when creating a pull request in the same session after successfully connecting their account.

## Problem
When users authenticated with GitHub (via OAuth or PAT) and then immediately tried to create a PR, they were prompted to authenticate again even though they had just successfully connected. This happened because the GitHub token validation check only ran once during app initialization and never re-ran after authentication changes.

## Root Cause
In `frontend/src/components/config-provider.tsx`, the `useEffect` that validates the GitHub token only depended on `[loading]`, which only changes during initial app load. When `reloadSystem()` was called after successful authentication, it updated the config but didn't trigger token re-validation, leaving the `githubTokenInvalid` state stale.

## Solution
Added `config?.github` to the useEffect dependency array (line 132), ensuring the token validation automatically re-runs whenever the GitHub configuration changes. This keeps the `githubTokenInvalid` state in sync with the actual authentication status.

## Changes
- Modified `frontend/src/components/config-provider.tsx:132`
  - Changed `}, [loading]);` to `}, [loading, config?.github]);`
  - Updated comment to reflect new behavior

## Testing
- ✅ Connect GitHub account via OAuth device flow
- ✅ Immediately create a PR in the same session (no re-authentication prompt)
- ✅ Token validation updates correctly after authentication
- ✅ Works for both OAuth and PAT authentication methods

## Impact
- Improved UX: No duplicate authentication prompts
- Better state management: Token validation stays synchronized with config changes
- Non-breaking: Follows React best practices for useEffect dependencies