### PR TITLE
fix: add AppKit framework linking for macOS builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1651,7 +1651,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "forge-app"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "android_logger",
  "anyhow",
@@ -1693,7 +1693,7 @@ dependencies = [
 
 [[package]]
 name = "forge-config"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1710,7 +1710,7 @@ dependencies = [
 
 [[package]]
 name = "forge-omni"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "reqwest 0.11.27",

--- a/forge-app/build.rs
+++ b/forge-app/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
+        println!("cargo:rustc-link-lib=framework=AppKit");
+        println!("cargo:rustc-link-lib=framework=Foundation");
+    }
+}


### PR DESCRIPTION
# fix: add AppKit framework linking for macOS builds

## Summary
Adds a `build.rs` script to `forge-app` that links the AppKit and Foundation frameworks when building for macOS targets. This fixes a linker error where `mac-notification-sys` (used via `notify-rust`) couldn't find `NSImage` and other AppKit symbols during the macOS build in CI.

The error was:
```
Undefined symbols for architecture arm64:
  "_OBJC_CLASS_$_NSImage", referenced from:
       in libmac_notification_sys-ef4bf75dab58a660.rlib
ld: symbol(s) not found for architecture arm64
```

## Review & Testing Checklist for Human
- [ ] **Verify macOS CI build passes** - This is the critical test. The fix hasn't been tested locally on macOS, only validated through code review and CI.
- [ ] **Check if Foundation framework is actually needed** - I linked both AppKit and Foundation proactively, but only AppKit may be required. Foundation was added as a precaution based on common practice.
- [ ] **Confirm no unexpected side effects** - Verify build times and binary size haven't changed significantly on macOS.

### Test Plan
1. Wait for CI to complete on this PR
2. Specifically check the "Build Rust binaries (non-Windows, native)" step for macOS ARM64
3. Verify the linker error no longer appears
4. If CI passes, the fix is working as intended

### Notes
- The `build.rs` file only affects macOS builds (checked via `CARGO_CFG_TARGET_OS`)
- This is a minimal, targeted fix that doesn't change any application logic
- The dependency chain is: `forge-app` → `services`/`local-deployment` (from forge-core) → `notify-rust` → `mac-notification-sys`
- Link to Devin run: https://app.devin.ai/sessions/4f3153dbe9c941e2b190aa2096205751
- Requested by: Felipe Rosa (felipe@namastex.ai) / @namastex888