### PR TITLE
fix: eliminate duplicate GitHub token validation calls

### DIFF
--- a/frontend/src/components/config-provider.tsx
+++ b/frontend/src/components/config-provider.tsx
@@ -110,7 +110,7 @@ export function UserSystemProvider({ children }: UserSystemProviderProps) {
     }
   }, [config?.language]);
 
-  // Check GitHub token validity after config loads and when GitHub config changes
+  // Check GitHub token validity after config loads and when auth tokens change
   useEffect(() => {
     if (loading) return;
     const checkToken = async () => {
@@ -129,7 +129,7 @@ export function UserSystemProvider({ children }: UserSystemProviderProps) {
       }
     };
     checkToken();
-  }, [loading, config?.github]);
+  }, [loading, config?.github?.oauth_token, config?.github?.pat]);
 
   const updateConfig = useCallback((updates: Partial<Config>) => {
     setConfig((prev) => (prev ? { ...prev, ...updates } : null));


### PR DESCRIPTION
## Summary
Fixes #148 - Eliminates duplicate API calls caused by overly broad useEffect dependency in config-provider.

## Changes
- Changed `config?.github` dependency to specific token fields (`oauth_token`, `pat`)
- Updated comment to reflect the more precise dependency behavior
- Reduces unnecessary GitHub token validation calls by 50%

## Problem
The useEffect hook was triggering on **every** config change (theme, language, onboarding steps, etc.) because it depended on the entire `config?.github` object reference. React's shallow comparison would see a new object reference even when the actual values were identical.

## Solution
Only depend on the actual auth token values that matter for validation:
```typescript
// Before
}, [loading, config?.github]);

// After  
}, [loading, config?.github?.oauth_token, config?.github?.pat]);
```

## Testing
Verified with Playwright browser automation:

**Before:**
- 2x `/api/auth/github/check` calls on page load
- Additional calls on theme changes, language changes, etc.

**After:**
- 1x `/api/auth/github/check` call on page load
- No token validation on unrelated config changes ✅

## Impact
- ✅ 50% reduction in GitHub token validation API calls
- ✅ Improved performance (fewer unnecessary re-renders)
- ✅ Reduced backend load
- ✅ Prevents potential GitHub API rate limiting

## Notes
Playwright testing revealed additional duplicate `/api/projects` and `/api/tasks` calls that are unrelated to this fix. Those are likely coming from React Query refetch behavior or multiple hook instances, and should be addressed separately.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)