### PR TITLE
fix health on dev

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -70,9 +70,13 @@ export default defineConfig({
     port: parseInt(process.env.FRONTEND_PORT || "3000"),
     proxy: {
       "/api": {
-        target: `http://localhost:${process.env.BACKEND_PORT || "3001"}`,
+        target: `http://localhost:${process.env.BACKEND_PORT || "8887"}`,
         changeOrigin: true,
         ws: true,
+      },
+      "/health": {
+        target: `http://localhost:${process.env.BACKEND_PORT || "8887"}`,
+        changeOrigin: true,
       },
     },
     fs: {


### PR DESCRIPTION
## ✅ Fix Applied

**Updated `frontend/vite.config.ts`:**

1. **Added `/health` endpoint to proxy configuration** (lines 77-80)
   - Now proxies `/health` requests to backend

2. **Fixed default backend port from `3001` to `8887`** (lines 73, 78)
   - Matches actual backend default and `.env.example` documentation

### Changes Made

```typescript
proxy: {
  "/api": {
    target: `http://localhost:${process.env.BACKEND_PORT || "8887"}`, // Changed from 3001
    changeOrigin: true,
    ws: true,
  },
  "/health": {  // NEW: Added /health proxy
    target: `http://localhost:${process.env.BACKEND_PORT || "8887"}`,
    changeOrigin: true,
  },
}
```

## 🔄 Next Step: Restart Vite

**The Vite dev server needs to be restarted for these changes to take effect.**

You can either:
1. Stop and restart `pnpm run dev`, or
2. Vite should auto-detect the config change and restart (check your terminal)

## ✅ Verification

After Vite restarts, you should see:

```bash
# Test endpoint:
curl http://localhost:3000/health
# Should return:
{
  "status": "ok",
  "service": "forge-app",
  "version": "0.7.2",
  ...
}
```

**In the UI Footer:**
- Version: **v0.7.2**
- Status: **healthy** (green animated dot)

The fix is complete - just needs the dev server restart to take effect!