### PR TITLE
Adjustments to system notification volume (automagik-forge 755b27a5)

### DIFF
--- a/frontend/src/pages/settings/GeneralSettings.tsx
+++ b/frontend/src/pages/settings/GeneralSettings.tsx
@@ -141,6 +141,7 @@ export function GeneralSettings() {
 
   const playSound = async (soundFile: SoundFile) => {
     const audio = new Audio(`/api/sounds/${soundFile}`);
+    audio.volume = 0.3; // Set volume to 30% of maximum
     try {
       await audio.play();
     } catch (err) {


### PR DESCRIPTION
System notifications use the full mixer volume when triggered via Forge. If possible, adjust that volume to be 30% of the maximim by default.