### PR TITLE
fix this and commit to dev (automagik-forge)

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -109,6 +109,11 @@ if (posthogKey && posthogHost) {
     enable_heatmaps: true, // Enable aggregate UX insights (mouse movement, clicks, scrolling)
     opt_out_capturing_by_default: true,
     mask_all_text: true, // Masks any text in error messages
+    session_recording: {
+      maskAllInputs: true, // Mask all input field values
+      maskTextSelector: '*', // Mask all text content by default
+      blockSelector: '[data-private]', // Block elements marked as private
+    },
     sanitize_properties: (properties) => {
       // Don't sanitize for namastexers (detected later via email)
       if (properties?.tracking_tier === 'namastexer') {


### PR DESCRIPTION
Here are some automated review suggestions for this pull request.

ℹ️ About Codex in GitHub
frontend/src/main.tsx
Comment on lines 92 to +99
// PostHog configuration
// Default keys for Namastex Labs analytics (write-only, safe to expose)
// Users can override via VITE_POSTHOG_API_KEY environment variable
const posthogKey = import.meta.env.VITE_POSTHOG_API_KEY ||
  'phc_' + 'KYI6y57aVECNO9aj5O28gNAz3r7BU0cTtEf50HQJZHd';
const posthogHost = import.meta.env.VITE_POSTHOG_API_ENDPOINT ||
  'https://us.i.posthog.com';
// SECURITY NOTE: This is a Project API Key (phc_*), which is write-only and designed
// for client-side use. It can ONLY send events to PostHog, not read data or modify
// project settings. This is standard practice for client-side analytics tools
// (like Google Analytics, Mixpanel, etc.) - the key is visible in the JS bundle anyway.
// Always embedded in code for consistent behavior across all build methods.
const posthogKey = 'phc_' + 'KYI6y57aVECNO9aj5O28gNAz3r7BU0cTtEf50HQJZHd';
const posthogHost = 'https://us.i.posthog.com';
@chatgpt-codex-connector
chatgpt-codex-connector bot
35 minutes ago
P2 Badge Restore env-based PostHog configuration

PostHog is now initialized with hard-coded key and host (lines 92-99), ignoring the previous VITE_POSTHOG_API_KEY/VITE_POSTHOG_API_ENDPOINT overrides. Any self-hosted or privacy-sensitive deployment that sets these env vars to disable analytics or point to its own PostHog instance will still send telemetry to the default cloud endpoint, which is a regression from earlier behavior and removes the documented opt-out.

Useful? React with 👍 / 👎.

@namastex888	Reply...
