### PR TITLE
fix(genie-widget): prevent hover flicker on Master Genie lamp button

### DIFF
--- a/frontend/src/components/genie-widgets/GenieMasterWidget.tsx
+++ b/frontend/src/components/genie-widgets/GenieMasterWidget.tsx
@@ -76,29 +76,40 @@ export const GenieMasterWidget: React.FC<GenieMasterWidgetProps> = () => {
   }
 
   // Lamp button - hidden at edge, slides in on hover from right
+  // Fixed hover zone prevents flicker when lamp slides in
   return (
     <div
-      className="fixed z-50 transition-all duration-300"
+      className="fixed z-50"
       style={{
         bottom: '46px', // 30px up from bottom-4
-        right: isHovering ? '20px' : '-20px',
+        right: 0,
+        width: '80px', // Stable hover detection zone
+        height: '60px',
       }}
       onMouseEnter={() => setIsHovering(true)}
       onMouseLeave={() => setIsHovering(false)}
     >
-      <button
-        onClick={isLoading ? undefined : handleOpenChat}
-        disabled={isLoading}
-        className="p-2 transition-all hover:scale-110 disabled:opacity-50 disabled:cursor-not-allowed"
-        aria-label="Open Master Genie"
-        title="Master Genie - AI Assistant"
+      <div
+        className="absolute transition-all duration-300"
+        style={{
+          right: isHovering ? '20px' : '-20px',
+          top: 0,
+        }}
       >
-        {isLoading ? (
-          <Loader2 className="h-10 w-10 text-foreground drop-shadow-lg animate-spin" />
-        ) : (
-          <Lamp className="h-10 w-10 text-foreground drop-shadow-lg" />
-        )}
-      </button>
+        <button
+          onClick={isLoading ? undefined : handleOpenChat}
+          disabled={isLoading}
+          className="p-2 transition-all hover:scale-110 disabled:opacity-50 disabled:cursor-not-allowed"
+          aria-label="Open Master Genie"
+          title="Master Genie - AI Assistant"
+        >
+          {isLoading ? (
+            <Loader2 className="h-10 w-10 text-foreground drop-shadow-lg animate-spin" />
+          ) : (
+            <Lamp className="h-10 w-10 text-zinc-700 dark:text-foreground drop-shadow-lg" />
+          )}
+        </button>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
# fix(genie-widget): prevent hover flicker on Master Genie lamp button

## Summary

Refactored the GenieMasterWidget hover interaction to eliminate the annoying flicker that occurred when hovering over the Master Genie lamp button from the right edge. The fix separates the stable hover detection zone (80x60px) from the animated sliding element, preventing the hover zone from moving with the button.

**Changes:**
- Outer container: Fixed position with stable hover detection zone
- Inner container: Absolute positioning with slide animation (`right: -20px` → `20px`)
- Lamp icon: Updated color for better light mode contrast (`text-foreground` → `text-zinc-700 dark:text-foreground`)

## Review & Testing Checklist for Human

**⚠️ Risk Level: YELLOW** - UX fix requiring manual testing

- [ ] **Test hover interaction**: Hover over the Master Genie lamp from the right edge of the screen - verify no flicker occurs when the lamp slides into view
- [ ] **Test lamp visibility**: Check lamp icon contrast in both light and dark modes - ensure it's visible and not too dark/light
- [ ] **Test button functionality**: Click the lamp button to open Master Genie chat - verify it still works correctly
- [ ] **Verify positioning**: Check that the lamp button is positioned correctly at the bottom-right and not cut off or misaligned

### Test Plan

1. Open the app in a browser
2. Navigate to a page where the Master Genie lamp button appears (bottom-right corner)
3. Move your mouse from the right edge toward the lamp - it should slide in smoothly without flickering
4. Click the lamp to open Master Genie - verify it opens correctly
5. Test in both light and dark modes to verify icon visibility

### Notes

- **No local testing**: I did NOT run the app locally or test the UI changes. All changes need manual verification.
- **Pre-existing lint error**: There's 1 lint error in `ProviderIcon.tsx` (unrelated to this PR). CI may fail on lint, but this error existed before this PR.
- **TypeScript check**: Passed with no errors
- **Original author**: This fix was originally implemented by GALI3600 and cherry-picked from the archived dev branch

---

**Link to Devin run**: https://app.devin.ai/sessions/a52a7fa288944e8fa3abc1c554d9c307  
**Requested by**: Felipe Rosa (felipe@namastex.ai), GitHub: @namastex888