### PR TITLE
fix: Remove onKanbanClick handler to prevent split view closure

### DIFF
--- a/frontend/src/components/layout/TasksLayout.tsx
+++ b/frontend/src/components/layout/TasksLayout.tsx
@@ -75,13 +75,11 @@ function SplitView({
   rightContent,
   rightHeader,
   rightLabel,
-  onRightContentClick,
 }: {
   attempt: ReactNode;
   rightContent: ReactNode;
   rightHeader?: ReactNode;
   rightLabel: string;
-  onRightContentClick?: () => void;
 }) {
   const [sizes] = useState<SplitSizes>(() =>
     loadSizes(STORAGE_KEYS.ATTEMPT_AUX, DEFAULT_ATTEMPT_AUX)
@@ -141,7 +139,6 @@ function SplitView({
             className="min-w-0 min-h-0 overflow-hidden"
             role="region"
             aria-label={rightLabel}
-            onClick={onRightContentClick}
           >
             {rightContent}
           </Panel>
@@ -164,14 +161,12 @@ function DesktopSimple({
   aux,
   mode,
   rightHeader,
-  onKanbanClick,
 }: {
   kanban: ReactNode;
   attempt: ReactNode;
   aux: ReactNode;
   mode: LayoutMode;
   rightHeader?: ReactNode;
-  onKanbanClick?: () => void;
 }) {
   // mode='chat' → Full screen chat only
   if (mode === 'chat') {
@@ -195,7 +190,6 @@ function DesktopSimple({
         rightContent={kanban}
         rightHeader={rightHeader}
         rightLabel="Kanban board"
-        onRightContentClick={onKanbanClick}
       />
     );
   }
@@ -236,8 +230,7 @@ export function TasksLayout({
   mode,
   isMobile = false,
   rightHeader,
-  onKanbanClick,
-}: TasksLayoutProps & { onKanbanClick?: () => void }) {
+}: TasksLayoutProps) {
   const desktopKey = isPanelOpen ? 'desktop-with-panel' : 'kanban-only';
 
   if (isMobile) {
@@ -325,7 +318,6 @@ export function TasksLayout({
         aux={aux}
         mode={mode}
         rightHeader={rightHeader}
-        onKanbanClick={onKanbanClick}
       />
     );
   }

--- a/frontend/src/pages/project-tasks.tsx
+++ b/frontend/src/pages/project-tasks.tsx
@@ -694,7 +694,6 @@ export function ProjectTasks() {
             mode={mode}
             isMobile={isMobilePortrait}
             rightHeader={rightHeader}
-            onKanbanClick={handleClosePanel}
           />
         </ExecutionProcessesProvider>
       </ReviewProvider>
@@ -714,7 +713,6 @@ export function ProjectTasks() {
             mode={mode}
             isMobile={isMobilePortrait}
             rightHeader={rightHeader}
-            onKanbanClick={handleClosePanel}
           />
         </ExecutionProcessesProvider>
       </ReviewProvider>
@@ -733,7 +731,6 @@ export function ProjectTasks() {
             mode={mode}
             isMobile={isMobile}
             rightHeader={rightHeader}
-            onKanbanClick={handleClosePanel}
           />
         </ExecutionProcessesProvider>
       </ReviewProvider>
@@ -747,7 +744,6 @@ export function ProjectTasks() {
       mode={mode}
       isMobile={isMobilePortrait}
       rightHeader={rightHeader}
-      onKanbanClick={handleClosePanel}
     />
   );
 


### PR DESCRIPTION
## Summary
Fixed issue where clicking anywhere on the kanban board immediately closed the attempt panel in split view mode, making it impossible to interact with tasks while viewing an attempt.

## Problem Description
When a user opened a task attempt in split view mode (`/projects/{id}/tasks/{taskId}/attempts/{attemptId}`), any click inside the kanban board triggered navigation back to `/projects/{id}/tasks`, closing the attempt panel.

**Affected interactions:**
- Clicking task cards to view/open them
- Dragging cards between columns
- Any UI element interaction within the kanban board

## Root Cause
The entire right panel in `TasksLayout.tsx` had an `onClick` handler that captured ALL click events, causing every interaction to trigger `handleClosePanel()`.

**Location:** `frontend/src/components/layout/TasksLayout.tsx:144`
```typescript
<Panel onClick={onRightContentClick}> // ❌ Captures ALL clicks
  {rightContent}
</Panel>
```

## Solution
Removed the `onKanbanClick` prop and `onClick` handler entirely from the layout component. Users can still close panels via:
- **ESC key** (already implemented via `useKeyExit`)
- **Explicit close buttons** in the UI
- **Navigation actions** (clicking different tasks)

## Changes Made

### Files Modified
1. **frontend/src/components/layout/TasksLayout.tsx**
   - Removed `onRightContentClick` parameter from `SplitView` function
   - Removed `onClick={onRightContentClick}` from Panel component
   - Removed `onKanbanClick` parameter from `DesktopSimple` function
   - Removed `onKanbanClick` from main `TasksLayout` export

2. **frontend/src/pages/project-tasks.tsx**
   - Removed `onKanbanClick={handleClosePanel}` from all 4 TasksLayout component calls

## Verification
- ✅ TypeScript compilation successful (`pnpm run check` passed)
- ✅ No type errors introduced
- ✅ ESC key functionality confirmed working (lines 268-277 in project-tasks.tsx)
- ✅ Changes match historical fixes (commits cc00deb6, 785702a9)

## Historical Context
This issue has been fixed twice before but was re-introduced:
1. **Commit cc00deb6** (Nov 14): Removed onClick handler from right panel
2. **Commit 785702a9** (Nov 14): Removed onKanbanClick prop from TasksLayout

Both previous fixes used the same solution: removing the click handler entirely.

## Testing Instructions
1. Navigate to `/projects/{id}/tasks/{taskId}/attempts/{attemptId}` (open attempt in split view)
2. Click on any task card in the kanban board
3. **Expected:** Task opens while split view stays open
4. **Previous behavior:** Split view immediately closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>