### PR TITLE
feat(ci): migrate Linux builds to self-hosted runner

### DIFF
--- a/.github/workflows/build-all-platforms.yml
+++ b/.github/workflows/build-all-platforms.yml
@@ -16,6 +16,9 @@ concurrency:
   group: build-all-platforms-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  CARGO_BUILD_JOBS: 6  # Limit parallelism for self-hosted runner (12 cores / 2)
+
 jobs:
   build:
     timeout-minutes: 60  # Increase timeout for slower macOS runners
@@ -23,14 +26,14 @@ jobs:
       fail-fast: false  # Don't cancel other platforms if one fails
       matrix:
         include:
-          - os: ubuntu-22.04  # Use 22.04 for GLIBC 2.35 compatibility (works on 22.04 AND 24.04)
+          - os: [self-hosted, Linux, X64]  # Self-hosted runner for Linux x64
             target: x86_64-unknown-linux-gnu
             platform: linux-x64
-          - os: ubuntu-22.04  # Use 22.04 for GLIBC 2.35 compatibility (works on 22.04 AND 24.04)
+          - os: [self-hosted, Linux, X64]  # Self-hosted runner for cross-compile
             target: aarch64-unknown-linux-gnu
             platform: linux-arm64
             use-zigbuild: true
-          - os: ubuntu-22.04  # Separate Android/Termux target (same binaries as linux-arm64)
+          - os: [self-hosted, Linux, X64]  # Self-hosted runner for Android/Termux
             target: aarch64-unknown-linux-gnu
             platform: android-arm64
             use-zigbuild: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,11 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   NODE_VERSION: 22
+  CARGO_BUILD_JOBS: 6  # Limit parallelism for self-hosted runner
 
 jobs:
   test:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v4
 
@@ -46,7 +47,6 @@ jobs:
           RUST_CACHE_DEBUG: true
         with:
           workspaces: "."
-          cache-provider: "buildjet"
           cache-on-failure: true
           shared-key: "shared"
           cache-all-crates: true


### PR DESCRIPTION
## Summary

- Migrate Linux x64, ARM64, and Android builds to self-hosted runner on docker-builder (CT 200)
- Migrate test workflow from BuildJet to self-hosted runner (fixes cancelled runs)
- Add `CARGO_BUILD_JOBS=6` to limit parallelism (12 cores / 2 = safer memory usage)
- Windows and macOS builds remain on GitHub-hosted runners

## Infrastructure Ready

| Component | Status |
|-----------|--------|
| Self-hosted runner | ✅ Online (`docker-builder-automagik`) |
| Labels | ✅ `[self-hosted, Linux, X64, fast-build]` |
| Build tools | ✅ Rust 1.91.1, Node 22, pnpm 10.23 |
| Cross-compile | ✅ aarch64 gcc, zig 0.13.0 |
| Tauri deps | ✅ webkit, gtk, appindicator, rsvg, ssl |

## Test plan

- [ ] Trigger workflow manually or with tag push
- [ ] Verify Linux x64 build completes on self-hosted runner
- [ ] Verify Linux ARM64 cross-compile works
- [ ] Verify Android cross-compile works
- [ ] Verify Windows/macOS still build on cloud runners
- [ ] Compare build times vs previous cloud builds

## Expected Build Times

| Platform | Expected (self-hosted) | Baseline (cloud) |
|----------|----------------------|------------------|
| linux-x64 | ~6-8 min | ~9 min |
| linux-arm64 | ~7-9 min | ~9.5 min |
| android-arm64 | ~8-10 min | ~9.5 min |

🤖 Generated with [Claude Code](https://claude.com/claude-code)