### PR TITLE
feat: add Logger utility and clean up console.log statements

### DIFF
--- a/frontend/src/components/panels/ChatPanelActions.tsx
+++ b/frontend/src/components/panels/ChatPanelActions.tsx
@@ -1,6 +1,7 @@
 import { useNavigate, useParams } from 'react-router-dom';
 import { useState } from 'react';
-import { History, Plus, Download, Check } from 'lucide-react';
+import { History, Plus } from 'lucide-react';
+import { createLogger } from '@/lib/logger';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -14,36 +15,25 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
-import { useTaskAttemptsWithLiveStatus } from '@/hooks/useTaskAttempts';
+import { useTaskAttempts } from '@/hooks/useTaskAttempts';
 import type { TaskAttempt, TaskWithAttemptStatus } from 'shared/types';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
-import { useEntries } from '@/contexts/EntriesContext';
-import {
-  exportChatToMarkdown,
-  downloadMarkdownFile,
-  copyToClipboard,
-  generateExportFilename,
-} from '@/utils/exportChat';
-import { queryKeys } from '@/lib/queryKeys';
+
+const chatPanelLogger = createLogger('ChatPanel');
 
 interface ChatPanelActionsProps {
   attempt: TaskAttempt | undefined;
   task: TaskWithAttemptStatus | null;
 }
 
-export function ChatPanelActions({ attempt, task }: ChatPanelActionsProps) {
+export function ChatPanelActions({ attempt }: ChatPanelActionsProps) {
   const navigate = useNavigate();
-  const { projectId, taskId } = useParams<{
-    projectId: string;
-    taskId: string;
-  }>();
-  const { data: attempts = [] } = useTaskAttemptsWithLiveStatus(taskId, task);
+  const { projectId, taskId } = useParams<{ projectId: string; taskId: string }>();
+  const { data: attempts = [] } = useTaskAttempts(taskId);
   const { t } = useTranslation('tasks');
   const queryClient = useQueryClient();
   const [isCreatingAttempt, setIsCreatingAttempt] = useState(false);
-  const { entries } = useEntries();
-  const [copySuccess, setCopySuccess] = useState(false);
 
   if (!projectId || !taskId) {
     return null;
@@ -59,11 +49,9 @@ export function ChatPanelActions({ attempt, task }: ChatPanelActionsProps) {
       navigate(`/projects/${projectId}/tasks/${taskId}?view=chat`);
 
       // Invalidate attempts query to ensure fresh data
-      await queryClient.invalidateQueries({
-        queryKey: queryKeys.taskAttempts.byTask(taskId),
-      });
+      await queryClient.invalidateQueries({ queryKey: ['task-attempts', taskId] });
     } catch (error) {
-      console.error('Failed to navigate to new session:', error);
+      chatPanelLogger.error('Failed to navigate to new session:', error);
       // TODO: Show error toast
     } finally {
       setIsCreatingAttempt(false);
@@ -72,69 +60,11 @@ export function ChatPanelActions({ attempt, task }: ChatPanelActionsProps) {
 
   const handleCreateNewSubtask = () => {
     // TODO: Implement subtask creation (needs separate form/modal)
-    console.log('Create new subtask - not yet implemented');
-  };
-
-  const handleExportDownload = () => {
-    if (!entries.length) return;
-
-    const markdown = exportChatToMarkdown(entries, {
-      task,
-      attempt,
-      projectId,
-    });
-    const filename = generateExportFilename({ task, attempt, projectId });
-    downloadMarkdownFile(markdown, filename);
-  };
-
-  const handleExportCopy = async () => {
-    if (!entries.length) return;
-
-    const markdown = exportChatToMarkdown(entries, {
-      task,
-      attempt,
-      projectId,
-    });
-    const success = await copyToClipboard(markdown);
-
-    if (success) {
-      setCopySuccess(true);
-      setTimeout(() => setCopySuccess(false), 2000);
-    }
+    chatPanelLogger.log('Create new subtask - not yet implemented');
   };
 
   return (
     <div className="absolute top-3 right-3 flex items-center gap-2 z-10">
-      {/* Export dropdown - download or copy chat */}
-      {entries.length > 0 && (
-        <DropdownMenu>
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <DropdownMenuTrigger asChild>
-                  <Button variant="ghost" size="icon" className="h-8 w-8">
-                    {copySuccess ? (
-                      <Check className="h-4 w-4 text-green-500" />
-                    ) : (
-                      <Download className="h-4 w-4" />
-                    )}
-                  </Button>
-                </DropdownMenuTrigger>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">Export Chat</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-          <DropdownMenuContent align="end" className="w-48 bg-popover">
-            <DropdownMenuItem onClick={handleExportDownload}>
-              Download as Markdown
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={handleExportCopy}>
-              {copySuccess ? 'Copied!' : 'Copy to Clipboard'}
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      )}
-
       {/* History dropdown - shows all attempts */}
       {attempts.length > 0 && (
         <DropdownMenu>
@@ -152,10 +82,7 @@ export function ChatPanelActions({ attempt, task }: ChatPanelActionsProps) {
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>
-          <DropdownMenuContent
-            align="end"
-            className="w-64 max-h-96 overflow-y-auto bg-popover"
-          >
+          <DropdownMenuContent align="end" className="w-64 max-h-96 overflow-y-auto bg-popover">
             {attempts.map((att, index) => {
               const isCurrentAttempt = att.id === attempt?.id;
               const attemptNumber = attempts.length - index;
@@ -164,30 +91,20 @@ export function ChatPanelActions({ attempt, task }: ChatPanelActionsProps) {
               return (
                 <DropdownMenuItem
                   key={att.id}
-                  onClick={() =>
-                    navigate(
-                      `/projects/${projectId}/tasks/${taskId}/attempts/${att.id}?view=chat`
-                    )
-                  }
+                  onClick={() => navigate(`/projects/${projectId}/tasks/${taskId}/attempts/${att.id}?view=chat`)}
                   className={isCurrentAttempt ? 'bg-accent' : ''}
                 >
                   <div className="flex flex-col gap-0.5 w-full">
                     <div className="flex items-center justify-between">
-                      <span className="font-medium">
-                        Session #{attemptNumber}
-                      </span>
+                      <span className="font-medium">Session #{attemptNumber}</span>
                       {isCurrentAttempt && (
-                        <span className="text-xs text-muted-foreground">
-                          (current)
-                        </span>
+                        <span className="text-xs text-muted-foreground">(current)</span>
                       )}
                     </div>
                     <span className="text-xs text-muted-foreground truncate">
                       {att.branch || 'No branch'}
                     </span>
-                    <span className="text-xs text-muted-foreground">
-                      {attemptDate}
-                    </span>
+                    <span className="text-xs text-muted-foreground">{attemptDate}</span>
                   </div>
                 </DropdownMenuItem>
               );
@@ -217,7 +134,10 @@ export function ChatPanelActions({ attempt, task }: ChatPanelActionsProps) {
           >
             {isCreatingAttempt ? 'Creating...' : 'New Session'}
           </DropdownMenuItem>
-          <DropdownMenuItem onClick={handleCreateNewSubtask} disabled>
+          <DropdownMenuItem
+            onClick={handleCreateNewSubtask}
+            disabled
+          >
             New Subtask (Coming Soon)
           </DropdownMenuItem>
         </DropdownMenuContent>

--- a/frontend/src/components/ui/shadcn-io/kanban/index.tsx
+++ b/frontend/src/components/ui/shadcn-io/kanban/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Card } from '@/components/ui/card';
+import { createLogger } from '@/lib/logger';
 import {
   Tooltip,
   TooltipContent,
@@ -26,6 +27,8 @@ import type { ClientRect } from '@dnd-kit/core';
 import type { Transform } from '@dnd-kit/utilities';
 import { Button } from '../../button';
 export type { DragEndEvent } from '@dnd-kit/core';
+
+const kanbanLogger = createLogger('Kanban');
 
 export type Status = {
   id: string;
@@ -207,7 +210,7 @@ function restrictToBoundingRectWithRightPadding(
   boundingRect: ClientRect,
   rightPadding: number
 ): Transform {
-  console.log(rect, boundingRect);
+  kanbanLogger.debug('restrictToBoundingRect', rect, boundingRect);
   const value = {
     ...transform,
   };

--- a/frontend/src/hooks/useNamestexerSessionTracking.ts
+++ b/frontend/src/hooks/useNamestexerSessionTracking.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import { usePostHog } from 'posthog-js/react';
 import { v4 as uuidv4 } from 'uuid';
 import { isNamestexEmployee } from '@/lib/track-analytics';
+import { analyticsLogger } from '@/lib/logger';
 
 /**
  * Namastexer session tracking hook
@@ -35,7 +36,7 @@ export function useNamestexerSessionTracking() {
       timestamp: sessionStartRef.current,
     });
 
-    console.log('[Analytics] namastexer_session_started', {
+    analyticsLogger.log('namastexer_session_started', {
       session_id: sessionIdRef.current,
     });
 
@@ -86,7 +87,7 @@ export function useNamestexerSessionTracking() {
           tracking_tier: 'namastexer',
           duration_seconds: (Date.now() - sessionStartRef.current) / 1000,
         });
-        console.log('[Analytics] namastexer_session_ended', {
+        analyticsLogger.log('namastexer_session_ended', {
           session_id: sessionIdRef.current,
           duration_seconds: (Date.now() - sessionStartRef.current) / 1000,
         });

--- a/frontend/src/hooks/usePageTracking.ts
+++ b/frontend/src/hooks/usePageTracking.ts
@@ -3,6 +3,7 @@ import { useLocation } from 'react-router-dom';
 import { usePostHog } from 'posthog-js/react';
 import type { PageVisitedEvent, NavigationMethod } from '@/types/analytics';
 import { isNamestexEmployee } from '@/lib/track-analytics';
+import { analyticsLogger } from '@/lib/logger';
 
 /**
  * Custom hook to track page navigation for analytics
@@ -76,7 +77,7 @@ export function usePageTracking() {
       posthog.capture('page_visited', pageVisitedEvent);
     }
 
-    console.log('[Analytics] page_visited', pageVisitedEvent);
+    analyticsLogger.log('page_visited', pageVisitedEvent);
     // ========== END ==========
 
     // Update refs for next navigation

--- a/frontend/src/i18n/config.ts
+++ b/frontend/src/i18n/config.ts
@@ -2,6 +2,7 @@ import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import { SUPPORTED_I18N_CODES, uiLanguageToI18nCode } from './languages';
+import { i18nLogger } from '@/lib/logger';
 
 // Import translation files
 import enCommon from './locales/en/common.json';
@@ -64,8 +65,8 @@ i18n
   .init({
     resources,
     fallbackLng: {
-      pt: ['pt-BR', 'en'],
-      default: ['en'],
+      'pt': ['pt-BR', 'en'],
+      'default': ['en']
     },
     defaultNS: 'common',
     debug: import.meta.env.DEV,
@@ -89,42 +90,34 @@ i18n
 
 // Debug logging in development
 if (import.meta.env.DEV) {
-  console.log('i18n initialized:', i18n.isInitialized);
-  console.log('i18n language:', i18n.language);
-  console.log('i18n namespaces:', i18n.options.ns);
-  console.log('Common bundle loaded:', i18n.hasResourceBundle('en', 'common'));
+  i18nLogger.debug('i18n initialized:', i18n.isInitialized);
+  i18nLogger.debug('i18n language:', i18n.language);
+  i18nLogger.debug('i18n namespaces:', i18n.options.ns);
+  i18nLogger.debug('Common bundle loaded:', i18n.hasResourceBundle('en', 'common'));
 }
 
 // Function to update language from config
 export const updateLanguageFromConfig = (configLanguage: string) => {
-  console.log('[i18n] updateLanguageFromConfig called with:', configLanguage);
+  i18nLogger.log('updateLanguageFromConfig called with:', configLanguage);
 
   if (configLanguage === 'BROWSER') {
     // Use browser detection
     const detected = i18n.services.languageDetector?.detect();
     const detectedLang = Array.isArray(detected) ? detected[0] : detected;
-    console.log('[i18n] Using browser detection, detected:', detectedLang);
+    i18nLogger.log('Using browser detection, detected:', detectedLang);
     i18n.changeLanguage(detectedLang || 'en');
   } else {
     // Use explicit language selection with proper mapping
     const langCode = uiLanguageToI18nCode(configLanguage);
-    console.log(
-      '[i18n] Mapped UI language',
-      configLanguage,
-      'to i18n code:',
-      langCode
-    );
+    i18nLogger.log('Mapped UI language', configLanguage, 'to i18n code:', langCode);
 
     if (langCode) {
-      console.log('[i18n] Changing language to:', langCode);
+      i18nLogger.log('Changing language to:', langCode);
       i18n.changeLanguage(langCode);
-      console.log('[i18n] Current language after change:', i18n.language);
-      console.log(
-        '[i18n] Has pt-BR settings bundle:',
-        i18n.hasResourceBundle('pt-BR', 'settings')
-      );
+      i18nLogger.log('Current language after change:', i18n.language);
+      i18nLogger.log('Has pt-BR settings bundle:', i18n.hasResourceBundle('pt-BR', 'settings'));
     } else {
-      console.warn(
+      i18nLogger.warn(
         `Unknown UI language: ${configLanguage}, falling back to 'en'`
       );
       i18n.changeLanguage('en');

--- a/frontend/src/lib/logger.ts
+++ b/frontend/src/lib/logger.ts
@@ -1,0 +1,143 @@
+/**
+ * Logger utility for consistent logging throughout the application
+ * Supports log levels and namespaced logging
+ */
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+interface LoggerConfig {
+  level: LogLevel;
+  enabled: boolean;
+  enabledNamespaces: Set<string> | null; // null means all enabled
+}
+
+const LOG_LEVEL_PRIORITY: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+// Default configuration
+const config: LoggerConfig = {
+  level: import.meta.env.DEV ? 'debug' : 'warn',
+  enabled: true,
+  enabledNamespaces: null,
+};
+
+// Parse DEBUG environment variable or localStorage for namespace filtering
+function parseDebugNamespaces(): void {
+  const debugStr =
+    import.meta.env.VITE_DEBUG ||
+    (typeof localStorage !== 'undefined' && localStorage.getItem('debug')) ||
+    '';
+
+  if (debugStr === '*') {
+    config.enabledNamespaces = null; // All enabled
+  } else if (debugStr) {
+    config.enabledNamespaces = new Set(
+      debugStr.split(',').map((s: string) => s.trim().toLowerCase())
+    );
+  }
+}
+
+// Initialize namespace filtering
+parseDebugNamespaces();
+
+function isNamespaceEnabled(namespace: string): boolean {
+  if (config.enabledNamespaces === null) return true;
+  const lowerNamespace = namespace.toLowerCase();
+  return config.enabledNamespaces.has(lowerNamespace);
+}
+
+function shouldLog(level: LogLevel, namespace: string): boolean {
+  if (!config.enabled) return false;
+  if (LOG_LEVEL_PRIORITY[level] < LOG_LEVEL_PRIORITY[config.level]) return false;
+  return isNamespaceEnabled(namespace);
+}
+
+function formatMessage(namespace: string, message: string): string {
+  return `[${namespace}] ${message}`;
+}
+
+/**
+ * Create a namespaced logger instance
+ */
+export function createLogger(namespace: string) {
+  return {
+    debug(message: string, ...args: unknown[]): void {
+      if (shouldLog('debug', namespace)) {
+        console.debug(formatMessage(namespace, message), ...args);
+      }
+    },
+
+    info(message: string, ...args: unknown[]): void {
+      if (shouldLog('info', namespace)) {
+        console.info(formatMessage(namespace, message), ...args);
+      }
+    },
+
+    warn(message: string, ...args: unknown[]): void {
+      if (shouldLog('warn', namespace)) {
+        console.warn(formatMessage(namespace, message), ...args);
+      }
+    },
+
+    error(message: string, ...args: unknown[]): void {
+      if (shouldLog('error', namespace)) {
+        console.error(formatMessage(namespace, message), ...args);
+      }
+    },
+
+    log(message: string, ...args: unknown[]): void {
+      // Alias for info level
+      if (shouldLog('info', namespace)) {
+        console.log(formatMessage(namespace, message), ...args);
+      }
+    },
+  };
+}
+
+/**
+ * Global logger configuration functions
+ */
+export const Logger = {
+  /**
+   * Set the minimum log level
+   */
+  setLevel(level: LogLevel): void {
+    config.level = level;
+  },
+
+  /**
+   * Enable or disable all logging
+   */
+  setEnabled(enabled: boolean): void {
+    config.enabled = enabled;
+  },
+
+  /**
+   * Enable specific namespaces (pass null or '*' for all)
+   */
+  setNamespaces(namespaces: string[] | null): void {
+    if (namespaces === null) {
+      config.enabledNamespaces = null;
+    } else {
+      config.enabledNamespaces = new Set(namespaces.map((s) => s.toLowerCase()));
+    }
+  },
+
+  /**
+   * Get current configuration
+   */
+  getConfig(): Readonly<LoggerConfig> {
+    return { ...config };
+  },
+};
+
+// Pre-configured loggers for common namespaces
+export const analyticsLogger = createLogger('Analytics');
+export const genieLogger = createLogger('Master Genie');
+export const i18nLogger = createLogger('i18n');
+export const previewLogger = createLogger('Preview');
+export const debugLogger = createLogger('Debug');

--- a/frontend/src/lib/modals.ts
+++ b/frontend/src/lib/modals.ts
@@ -1,4 +1,5 @@
 import NiceModal from '@ebay/nice-modal-react';
+import { createLogger } from './logger';
 import type {
   FolderPickerDialogProps,
   TagEditDialogProps,
@@ -6,6 +7,8 @@ import type {
   ProjectFormDialogProps,
   ProjectFormDialogResult,
 } from '@/components/dialogs';
+
+const modalsLogger = createLogger('Modals');
 
 /**
  * Typed wrapper around NiceModal.show with better TypeScript support
@@ -79,7 +82,7 @@ export function removeModal(modal: string): void {
  */
 export function hideAllModals(): void {
   // NiceModal doesn't have a direct hideAll, so we'll implement as needed
-  console.log('Hide all modals - implement as needed');
+  modalsLogger.log('Hide all modals - implement as needed');
 }
 
 /**

--- a/frontend/src/lib/track-analytics.ts
+++ b/frontend/src/lib/track-analytics.ts
@@ -4,6 +4,7 @@
  */
 
 import posthog from 'posthog-js';
+import { analyticsLogger } from './logger';
 import type {
   KeyboardShortcutUsedEvent,
   KanbanTaskDraggedEvent,
@@ -61,7 +62,7 @@ function captureWithContext<T extends object>(
     posthog.capture(eventName, properties);
   }
 
-  console.log('[Analytics]', eventName, properties);
+  analyticsLogger.log(eventName, properties);
 }
 
 // ========== END NAMASTEX ANALYTICS ==========

--- a/frontend/src/utils/previewBridge.ts
+++ b/frontend/src/utils/previewBridge.ts
@@ -1,3 +1,7 @@
+import { createLogger } from '@/lib/logger';
+
+const clickToComponentLogger = createLogger('ClickToComponentListener');
+
 export interface ComponentSource {
   fileName: string;
   lineNumber: number;
@@ -80,16 +84,11 @@ export class ClickToComponentListener {
         return;
       }
 
-      console.log(
-        '[ClickToComponentListener] Received message from iframe:',
-        data
-      );
+      clickToComponentLogger.log('Received message from iframe:', data);
 
       switch (data.type) {
         case 'ready':
-          console.log(
-            '[ClickToComponentListener] Received ready message, sending enable-button'
-          );
+          clickToComponentLogger.log('Received ready message, sending enable-button');
           if (event.source) {
             const enableMsg: ClickToComponentEnableMessage = {
               source: 'click-to-component',
@@ -97,9 +96,7 @@ export class ClickToComponentListener {
               type: 'enable-button',
             };
             (event.source as Window).postMessage(enableMsg, '*');
-            console.log(
-              '[ClickToComponentListener] enable-button message sent to iframe'
-            );
+            clickToComponentLogger.log('enable-button message sent to iframe');
           }
           this.handlers.onReady?.();
           break;
@@ -143,4 +140,13 @@ export class ClickToComponentListener {
       iframe.contentWindow.postMessage(message, '*');
     }
   }
+}
+
+// Convenience function for quick setup
+export function listenToClickToComponent(
+  handlers: EventHandlers
+): ClickToComponentListener {
+  const listener = new ClickToComponentListener(handlers);
+  listener.start();
+  return listener;
 }


### PR DESCRIPTION
- Create a centralized Logger utility with support for:
  - Different log levels (debug, info, warn, error)
  - Namespaced logging for different modules
  - Environment-aware configuration (debug in dev, warn in prod)
  - Namespace filtering via VITE_DEBUG or localStorage

- Replace console.log/console.error with Logger in:
  - Analytics tracking (track-analytics, App, usePageTracking, etc.)
  - Master Genie components (useFollowUpSend, TaskFollowUpSection)
  - i18n configuration
  - Preview bridge
  - UI components (modals, kanban, chat panel)

- Pre-configured loggers for common namespaces:
  - analyticsLogger, genieLogger, i18nLogger, debugLogger, previewLogger