### PR TITLE
chore: bump forge-core to v0.8.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,7 +950,7 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 [[package]]
 name = "codex-app-server-protocol"
 version = "0.63.0"
-source = "git+https://github.com/namastexlabs/codex?branch=main#5d40e833a00f04abd2a4de8c0e76ce904366f98d"
+source = "git+https://github.com/namastexlabs/codex?branch=main#885fa3a11c439c82a577a02c2bccb81464aa11d4"
 dependencies = [
  "anyhow",
  "clap",
@@ -968,7 +968,7 @@ dependencies = [
 [[package]]
 name = "codex-git"
 version = "0.63.0"
-source = "git+https://github.com/namastexlabs/codex?branch=main#5d40e833a00f04abd2a4de8c0e76ce904366f98d"
+source = "git+https://github.com/namastexlabs/codex?branch=main#885fa3a11c439c82a577a02c2bccb81464aa11d4"
 dependencies = [
  "once_cell",
  "regex",
@@ -983,7 +983,7 @@ dependencies = [
 [[package]]
 name = "codex-protocol"
 version = "0.63.0"
-source = "git+https://github.com/namastexlabs/codex?branch=main#5d40e833a00f04abd2a4de8c0e76ce904366f98d"
+source = "git+https://github.com/namastexlabs/codex?branch=main#885fa3a11c439c82a577a02c2bccb81464aa11d4"
 dependencies = [
  "base64 0.22.1",
  "codex-git",
@@ -1008,7 +1008,7 @@ dependencies = [
 [[package]]
 name = "codex-utils-cache"
 version = "0.63.0"
-source = "git+https://github.com/namastexlabs/codex?branch=main#5d40e833a00f04abd2a4de8c0e76ce904366f98d"
+source = "git+https://github.com/namastexlabs/codex?branch=main#885fa3a11c439c82a577a02c2bccb81464aa11d4"
 dependencies = [
  "lru",
  "sha1",
@@ -1018,7 +1018,7 @@ dependencies = [
 [[package]]
 name = "codex-utils-image"
 version = "0.63.0"
-source = "git+https://github.com/namastexlabs/codex?branch=main#5d40e833a00f04abd2a4de8c0e76ce904366f98d"
+source = "git+https://github.com/namastexlabs/codex?branch=main#885fa3a11c439c82a577a02c2bccb81464aa11d4"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -1254,8 +1254,8 @@ checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "db"
-version = "0.0.115"
-source = "git+https://github.com/namastexlabs/forge-core.git?tag=v0.8.1#146d65d2cec07006a45bacde1fad3374fa7b4a6c"
+version = "0.8.3"
+source = "git+https://github.com/namastexlabs/forge-core.git?tag=v0.8.3#509205d7b04454235aada161eb3cf9f2966933bc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1309,8 +1309,8 @@ dependencies = [
 
 [[package]]
 name = "deployment"
-version = "0.0.115"
-source = "git+https://github.com/namastexlabs/forge-core.git?tag=v0.8.1#146d65d2cec07006a45bacde1fad3374fa7b4a6c"
+version = "0.8.3"
+source = "git+https://github.com/namastexlabs/forge-core.git?tag=v0.8.3#509205d7b04454235aada161eb3cf9f2966933bc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1648,8 +1648,8 @@ dependencies = [
 
 [[package]]
 name = "executors"
-version = "0.0.115"
-source = "git+https://github.com/namastexlabs/forge-core.git?tag=v0.8.1#146d65d2cec07006a45bacde1fad3374fa7b4a6c"
+version = "0.8.3"
+source = "git+https://github.com/namastexlabs/forge-core.git?tag=v0.8.3#509205d7b04454235aada161eb3cf9f2966933bc"
 dependencies = [
  "agent-client-protocol",
  "async-trait",
@@ -3061,8 +3061,8 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "local-deployment"
-version = "0.0.115"
-source = "git+https://github.com/namastexlabs/forge-core.git?tag=v0.8.1#146d65d2cec07006a45bacde1fad3374fa7b4a6c"
+version = "0.8.3"
+source = "git+https://github.com/namastexlabs/forge-core.git?tag=v0.8.3#509205d7b04454235aada161eb3cf9f2966933bc"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3162,7 +3162,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 [[package]]
 name = "mcp-types"
 version = "0.63.0"
-source = "git+https://github.com/namastexlabs/codex?branch=main#5d40e833a00f04abd2a4de8c0e76ce904366f98d"
+source = "git+https://github.com/namastexlabs/codex?branch=main#885fa3a11c439c82a577a02c2bccb81464aa11d4"
 dependencies = [
  "schemars 1.1.0",
  "serde",
@@ -4946,8 +4946,8 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.0.115"
-source = "git+https://github.com/namastexlabs/forge-core.git?tag=v0.8.1#146d65d2cec07006a45bacde1fad3374fa7b4a6c"
+version = "0.8.3"
+source = "git+https://github.com/namastexlabs/forge-core.git?tag=v0.8.3#509205d7b04454235aada161eb3cf9f2966933bc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4992,8 +4992,8 @@ dependencies = [
 
 [[package]]
 name = "services"
-version = "0.0.115"
-source = "git+https://github.com/namastexlabs/forge-core.git?tag=v0.8.1#146d65d2cec07006a45bacde1fad3374fa7b4a6c"
+version = "0.8.3"
+source = "git+https://github.com/namastexlabs/forge-core.git?tag=v0.8.3#509205d7b04454235aada161eb3cf9f2966933bc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6232,8 +6232,8 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utils"
-version = "0.0.115"
-source = "git+https://github.com/namastexlabs/forge-core.git?tag=v0.8.1#146d65d2cec07006a45bacde1fad3374fa7b4a6c"
+version = "0.8.3"
+source = "git+https://github.com/namastexlabs/forge-core.git?tag=v0.8.3#509205d7b04454235aada161eb3cf9f2966933bc"
 dependencies = [
  "async-stream",
  "axum",

--- a/forge-app/Cargo.toml
+++ b/forge-app/Cargo.toml
@@ -50,13 +50,13 @@ uuid = { version = "1.0", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 
 # Upstream crate dependencies (from git)
-db = { git = "https://github.com/namastexlabs/forge-core.git", tag = "v0.8.1" }
-services = { git = "https://github.com/namastexlabs/forge-core.git", tag = "v0.8.1" }
-server = { git = "https://github.com/namastexlabs/forge-core.git", tag = "v0.8.1" }
-deployment = { git = "https://github.com/namastexlabs/forge-core.git", tag = "v0.8.1" }
-local-deployment = { git = "https://github.com/namastexlabs/forge-core.git", tag = "v0.8.1" }
-executors = { git = "https://github.com/namastexlabs/forge-core.git", tag = "v0.8.1" }
-utils = { git = "https://github.com/namastexlabs/forge-core.git", tag = "v0.8.1" }
+db = { git = "https://github.com/namastexlabs/forge-core.git", tag = "v0.8.3" }
+services = { git = "https://github.com/namastexlabs/forge-core.git", tag = "v0.8.3" }
+server = { git = "https://github.com/namastexlabs/forge-core.git", tag = "v0.8.3" }
+deployment = { git = "https://github.com/namastexlabs/forge-core.git", tag = "v0.8.3" }
+local-deployment = { git = "https://github.com/namastexlabs/forge-core.git", tag = "v0.8.3" }
+executors = { git = "https://github.com/namastexlabs/forge-core.git", tag = "v0.8.3" }
+utils = { git = "https://github.com/namastexlabs/forge-core.git", tag = "v0.8.3" }
 
 # Forge extensions
 forge-omni = { path = "../forge-extensions/omni" }

--- a/forge-extensions/config/Cargo.toml
+++ b/forge-extensions/config/Cargo.toml
@@ -13,7 +13,7 @@ sqlx = { version = "0.8.6", features = ["runtime-tokio-rustls", "sqlite", "uuid"
 uuid = { version = "1.0", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 forge-omni = { path = "../omni" }
-services = { git = "https://github.com/namastexlabs/forge-core.git", tag = "v0.8.1" }
+services = { git = "https://github.com/namastexlabs/forge-core.git", tag = "v0.8.3" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
## Summary
- Bumps forge-core dependency from v0.8.1 to v0.8.3

## Changes in forge-core v0.8.3
- **Claude Code executor**: 2.0.31 → 2.0.55
  - MCP nested schema references fix
  - Memory crash fix for large files
  - Native binary faster startup
- **Gemini CLI executor**: 0.8.1 → 0.18.4
  - Latest stable release
  - `--experimental-acp` flag still supported

## Tech Council Approval
- Claude Code: 3/3 APPROVE
- Gemini CLI: 2/3 APPROVE

## Files Updated
- `forge-app/Cargo.toml` (7 dependencies)
- `forge-extensions/config/Cargo.toml` (1 dependency)
- `Cargo.lock` refreshed

## Testing
- [x] `cargo check` passes
- [ ] Verify executor selection end-to-end
- [ ] Run `npm run generate-types` to sync TypeScript types

---
*Auto-generated by forge-core bump workflow*