### PR TITLE
fix: add TypeScript strict null checks to frontend hooks

### DIFF
--- a/frontend/src/hooks/useConversationHistory.ts
+++ b/frontend/src/hooks/useConversationHistory.ts
@@ -158,7 +158,7 @@ export const useConversationHistory = ({
   const getLiveExecutionProcess = (
     executionProcessId: string
   ): ExecutionProcess | undefined => {
-    return executionProcesses?.current.find(
+    return executionProcesses.current?.find(
       (executionProcess) => executionProcess.id === executionProcessId
     );
   };
@@ -219,15 +219,15 @@ export const useConversationHistory = ({
   };
 
   const getActiveAgentProcess = (): ExecutionProcess | null => {
-    const activeProcesses = executionProcesses?.current.filter(
+    const activeProcesses = executionProcesses.current?.filter(
       (p) =>
         p.status === ExecutionProcessStatus.running &&
         p.run_reason !== 'devserver'
-    );
+    ) ?? [];
     if (activeProcesses.length > 1) {
       console.error('More than one active execution process found');
     }
-    return activeProcesses[0] || null;
+    return activeProcesses[0] ?? null;
   };
 
   const flattenEntries = (

--- a/frontend/src/hooks/useDiffStream.ts
+++ b/frontend/src/hooks/useDiffStream.ts
@@ -53,7 +53,7 @@ export const useDiffStream = (
   const diffs = useMemo(() => {
     return Object.values(data?.entries ?? {})
       .filter((entry): entry is PatchType & { type: 'DIFF'; content: Diff } =>
-        entry?.type === 'DIFF' && entry.content != null
+        entry.type === 'DIFF' && entry.content != null
       )
       .map((entry) => entry.content);
   }, [data?.entries]);

--- a/frontend/src/hooks/useDiffStream.ts
+++ b/frontend/src/hooks/useDiffStream.ts
@@ -52,7 +52,9 @@ export const useDiffStream = (
 
   const diffs = useMemo(() => {
     return Object.values(data?.entries ?? {})
-      .filter((entry) => entry?.type === 'DIFF')
+      .filter((entry): entry is PatchType & { type: 'DIFF'; content: Diff } =>
+        entry?.type === 'DIFF' && entry.content != null
+      )
       .map((entry) => entry.content);
   }, [data?.entries]);
 


### PR DESCRIPTION
- useAgentTasks: add null check for executor.split() to prevent runtime errors when executor is undefined
- useConversationHistory: fix console.warn! typo and improve null checks for executionProcesses.current access patterns
- useTaskMutations: add getExecutorString helper for safe executor extraction, replace || with ?? for better nullish handling
- useDiffStream: add type guard to ensure entry.content is not null before mapping

These changes prevent potential runtime errors when handling API responses that may contain null/undefined values.