### PR TITLE
chore(deps): update forge-inspector to 0.1.0-rc.8

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -60,7 +60,7 @@
     "clsx": "^2.0.0",
     "embla-carousel-react": "^8.6.0",
     "fancy-ansi": "^0.1.3",
-    "forge-inspector": "^0.0.6",
+    "forge-inspector": "^0.1.0-rc.8",
     "i18next": "^25.5.2",
     "i18next-browser-languagedetector": "^8.2.0",
     "lucide-react": "^0.539.0",


### PR DESCRIPTION
## Summary

Automated PR to update forge-inspector dependency.

- **New version**: 0.1.0-rc.8
- **npm tag**: next
- **Source**: [forge-inspector release](https://github.com/namastexlabs/forge-inspector/releases/tag/v0.1.0-rc.8)

---
🤖 Generated by [forge-inspector release workflow](https://github.com/namastexlabs/forge-inspector/actions)