### PR TITLE
fix(deps): sync rmcp 0.10.0 and openssl-sys vendored with forge-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7009,3 +7009,18 @@ dependencies = [
  "syn 2.0.111",
  "winnow",
 ]
+
+[[patch.unused]]
+name = "codex-app-server-protocol"
+version = "0.63.0"
+source = "git+https://github.com/namastexlabs/codex.git?branch=main#27dd137e257b3e2b1857ebb02113178e064722c7"
+
+[[patch.unused]]
+name = "codex-protocol"
+version = "0.63.0"
+source = "git+https://github.com/namastexlabs/codex.git?branch=main#27dd137e257b3e2b1857ebb02113178e064722c7"
+
+[[patch.unused]]
+name = "mcp-types"
+version = "0.63.0"
+source = "git+https://github.com/namastexlabs/codex.git?branch=main#27dd137e257b3e2b1857ebb02113178e064722c7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ ts-rs = { git = "https://github.com/xazukx/ts-rs.git", branch = "use-ts-enum", f
 schemars = { version = "1.0.4", features = ["derive", "chrono04", "uuid1", "preserve_order"] }
 
 # forge-core workspace dependencies (required for dev-core mode)
-rmcp = { version = "0.8.5" }
+rmcp = { version = "0.10.0" }
 
 # Codex dependencies from namastexlabs fork (patched via .cargo/config.toml)
 codex-protocol = "0.63.0"


### PR DESCRIPTION
## Summary
- Updates rmcp from 0.8.5 to 0.10.0 to match forge-core
- Syncs with forge-core openssl-sys vendored feature for musl builds

## Changes
- `Cargo.toml`: rmcp 0.8.5 → 0.10.0
- `Cargo.lock`: Updated dependencies

## Test plan
- [ ] CI passes
- [ ] When merged, automation triggers forge-core pre-release
- [ ] Linux musl build passes with vendored OpenSSL